### PR TITLE
Add showMyLocationButton property, cameraPosition rename

### DIFF
--- a/packages/google_atlas/CHANGELOG.md
+++ b/packages/google_atlas/CHANGELOG.md
@@ -1,4 +1,8 @@
 # google_atlas
+# v0.0.5 (2019-6-19)
+
+- `showMyLocationButton` added to GoogleAtlas 
+- `initialCameraPosition` renamed to `cameraPosition`
 
 # v0.0.4 (2019-5-22)
 

--- a/packages/google_atlas/README.md
+++ b/packages/google_atlas/README.md
@@ -34,7 +34,7 @@ class MyApp extends StatelessWidget {
 }
 
 class AtlasSample extends StatelessWidget {
-  final CameraPosition _initialCameraPosition = CameraPosition(
+  final CameraPosition cameraPosition = CameraPosition(
     target: CoordinatePair(
       latitude: 37.42796133580664,
       longitude: -122.085749655962,
@@ -57,7 +57,7 @@ class AtlasSample extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Atlas(
-        initialCameraPosition: _initialCameraPosition,
+        initialCameraPosition: cameraPosition,
         markers: _markers,
       ),
     );

--- a/packages/google_atlas/example/main.dart
+++ b/packages/google_atlas/example/main.dart
@@ -18,7 +18,7 @@ class MyApp extends StatelessWidget {
 }
 
 class AtlasSample extends StatelessWidget {
-  final CameraPosition _initialCameraPosition = CameraPosition(
+  final CameraPosition cameraPosition = CameraPosition(
     target: LatLng(
       latitude: 37.42796133580664,
       longitude: -122.085749655962,
@@ -29,7 +29,7 @@ class AtlasSample extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Atlas(
-        initialCameraPosition: _initialCameraPosition,
+        cameraPosition: cameraPosition,
       ),
     );
   }

--- a/packages/google_atlas/lib/src/google_atlas.dart
+++ b/packages/google_atlas/lib/src/google_atlas.dart
@@ -6,15 +6,17 @@ import 'package:google_maps_flutter/google_maps_flutter.dart' as GoogleMaps;
 class GoogleAtlas extends Provider {
   @override
   Widget build({
-    @required CameraPosition initialCameraPosition,
+    @required CameraPosition cameraPosition,
     @required Set<Marker> markers,
     @required bool showMyLocation,
+    @required bool showMyLocationButton,
     ArgumentCallback<LatLng> onTap,
   }) {
     return GoogleMaps.GoogleMap(
       myLocationEnabled: showMyLocation,
+      myLocationButtonEnabled: showMyLocationButton,
       mapType: GoogleMaps.MapType.normal,
-      initialCameraPosition: _toGoogleCameraPosition(initialCameraPosition),
+      initialCameraPosition: _toGoogleCameraPosition(cameraPosition),
       markers: markers.map((m) => _toGoogleMarker(m)).toSet(),
       onTap: _toGoogleOnTap(onTap),
     );

--- a/packages/google_atlas/pubspec.yaml
+++ b/packages/google_atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_atlas
 description: Google Map Provider for Atlas, an extensible map abstraction for Flutter with support for multiple map providers
-version: 0.0.4
+version: 0.0.5
 authors:
   - Jorge Coca <jcocaramos@gmail.com>
   - Felix Angelov <felangelov@gmail.com>
@@ -16,7 +16,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  atlas: ^0.0.4
+  atlas: ^0.0.5
   google_maps_flutter: ^0.5.13
 
 dev_dependencies:

--- a/packages/google_atlas/test/google_atlas_test.dart
+++ b/packages/google_atlas/test/google_atlas_test.dart
@@ -13,7 +13,7 @@ main() {
 
     test('should return correct GoogleMap when build is called with no markers',
         () {
-      final initialCameraPosition = CameraPosition(
+      final cameraPosition = CameraPosition(
         target: LatLng(latitude: 0.0, longitude: -190.0),
         zoom: 10.0,
       );
@@ -23,9 +23,10 @@ main() {
       );
       final expectedGoogleMarkers = Set<GoogleMaps.Marker>();
       final googleMap = googleAtlas.build(
-        initialCameraPosition: initialCameraPosition,
+        cameraPosition: cameraPosition,
         markers: Set<Marker>(),
         showMyLocation: false,
+        showMyLocationButton: false,
       );
       expect(googleMap is GoogleMaps.GoogleMap, true);
       expect(
@@ -44,7 +45,7 @@ main() {
 
     test('should return correct GoogleMap when build is called with markers',
         () {
-      final initialCameraPosition = CameraPosition(
+      final cameraPosition = CameraPosition(
         target: LatLng(latitude: 0.0, longitude: -190.0),
         zoom: 10.0,
       );
@@ -60,7 +61,7 @@ main() {
         )
       ]);
       final googleMap = googleAtlas.build(
-        initialCameraPosition: initialCameraPosition,
+        cameraPosition: cameraPosition,
         markers: Set<Marker>.from([
           Marker(
             id: 'markerId',
@@ -69,6 +70,7 @@ main() {
           ),
         ]),
         showMyLocation: false,
+        showMyLocationButton: false,
       );
       expect(googleMap is GoogleMaps.GoogleMap, true);
       expect(
@@ -87,7 +89,7 @@ main() {
 
     test('should return correct GoogleMap when build is called without onTap',
         () {
-      final initialCameraPosition = CameraPosition(
+      final cameraPosition = CameraPosition(
         target: LatLng(latitude: 0.0, longitude: -190.0),
         zoom: 10.0,
       );
@@ -96,9 +98,10 @@ main() {
         zoom: 10.0,
       );
       final googleMap = googleAtlas.build(
-        initialCameraPosition: initialCameraPosition,
+        cameraPosition: cameraPosition,
         markers: Set<Marker>(),
         showMyLocation: false,
+        showMyLocationButton: false,
       );
       expect(googleMap is GoogleMaps.GoogleMap, true);
       expect(
@@ -117,7 +120,7 @@ main() {
     });
 
     test('should return correct GoogleMap when build is called with onTap', () {
-      final initialCameraPosition = CameraPosition(
+      final cameraPosition = CameraPosition(
         target: LatLng(latitude: 0.0, longitude: -190.0),
         zoom: 10.0,
       );
@@ -132,9 +135,10 @@ main() {
         onTapPosition = position;
       };
       final googleMap = googleAtlas.build(
-        initialCameraPosition: initialCameraPosition,
+        cameraPosition: cameraPosition,
         markers: Set<Marker>(),
         showMyLocation: false,
+        showMyLocationButton: false,
         onTap: onTap,
       );
       expect(googleMap is GoogleMaps.GoogleMap, true);
@@ -155,7 +159,7 @@ main() {
     test(
         'should return correct GoogleMap when build is called with showMyLocation = false',
         () {
-      final initialCameraPosition = CameraPosition(
+      final cameraPosition = CameraPosition(
         target: LatLng(latitude: 0.0, longitude: -190.0),
         zoom: 10.0,
       );
@@ -165,9 +169,10 @@ main() {
       );
       final expectedMyLocationEnabled = false;
       final googleMap = googleAtlas.build(
-        initialCameraPosition: initialCameraPosition,
+        cameraPosition: cameraPosition,
         markers: Set<Marker>(),
         showMyLocation: expectedMyLocationEnabled,
+        showMyLocationButton: false,
       );
       expect(googleMap is GoogleMaps.GoogleMap, true);
       expect(
@@ -187,7 +192,7 @@ main() {
     test(
         'should return correct GoogleMap when build is called with showMyLocation = true',
         () {
-      final initialCameraPosition = CameraPosition(
+      final cameraPosition = CameraPosition(
         target: LatLng(latitude: 0.0, longitude: -190.0),
         zoom: 10.0,
       );
@@ -197,9 +202,10 @@ main() {
       );
       final expectedMyLocationEnabled = true;
       final googleMap = googleAtlas.build(
-        initialCameraPosition: initialCameraPosition,
+        cameraPosition: cameraPosition,
         markers: Set<Marker>(),
         showMyLocation: expectedMyLocationEnabled,
+        showMyLocationButton: false,
       );
       expect(googleMap is GoogleMaps.GoogleMap, true);
       expect(
@@ -213,6 +219,80 @@ main() {
       expect(
         (googleMap as GoogleMaps.GoogleMap).myLocationEnabled,
         expectedMyLocationEnabled,
+      );
+    });
+
+    test(
+        'should return correct GoogleMap when build is called with showMyLocationButton = false',
+        () {
+      final cameraPosition = CameraPosition(
+        target: LatLng(latitude: 0.0, longitude: -190.0),
+        zoom: 10.0,
+      );
+      final expectedInitialGoogleCameraPosition = GoogleMaps.CameraPosition(
+        target: GoogleMaps.LatLng(0.0, -190.0),
+        zoom: 10.0,
+      );
+      final expectedMyLocationButtonEnabled = false;
+      final googleMap = googleAtlas.build(
+        cameraPosition: cameraPosition,
+        markers: Set<Marker>(),
+        showMyLocation: false,
+        showMyLocationButton: expectedMyLocationButtonEnabled,
+      );
+      expect(googleMap is GoogleMaps.GoogleMap, true);
+      expect(
+        (googleMap as GoogleMaps.GoogleMap).initialCameraPosition,
+        expectedInitialGoogleCameraPosition,
+      );
+      expect(
+        (googleMap as GoogleMaps.GoogleMap).mapType,
+        GoogleMaps.MapType.normal,
+      );
+      expect(
+        (googleMap as GoogleMaps.GoogleMap).myLocationEnabled,
+        false,
+      );
+      expect(
+        (googleMap as GoogleMaps.GoogleMap).myLocationButtonEnabled,
+        expectedMyLocationButtonEnabled,
+      );
+    });
+
+    test(
+        'should return correct GoogleMap when build is called with showMyLocation = true',
+        () {
+      final cameraPosition = CameraPosition(
+        target: LatLng(latitude: 0.0, longitude: -190.0),
+        zoom: 10.0,
+      );
+      final expectedInitialGoogleCameraPosition = GoogleMaps.CameraPosition(
+        target: GoogleMaps.LatLng(0.0, -190.0),
+        zoom: 10.0,
+      );
+      final expectedMyLocationButtonEnabled = true;
+      final googleMap = googleAtlas.build(
+        cameraPosition: cameraPosition,
+        markers: Set<Marker>(),
+        showMyLocation: false,
+        showMyLocationButton: expectedMyLocationButtonEnabled,
+      );
+      expect(googleMap is GoogleMaps.GoogleMap, true);
+      expect(
+        (googleMap as GoogleMaps.GoogleMap).initialCameraPosition,
+        expectedInitialGoogleCameraPosition,
+      );
+      expect(
+        (googleMap as GoogleMaps.GoogleMap).mapType,
+        GoogleMaps.MapType.normal,
+      );
+      expect(
+        (googleMap as GoogleMaps.GoogleMap).myLocationEnabled,
+        false,
+      );
+      expect(
+        (googleMap as GoogleMaps.GoogleMap).myLocationButtonEnabled,
+        expectedMyLocationButtonEnabled,
       );
     });
   });


### PR DESCRIPTION
Added showMyLocationButton as a parameter to Google Atlas for toggling that button.  Renamed parameter initialCameraPosition to CameraPosition to be more accurate