### PR TITLE
Add zIndex to Atlas Marker

### DIFF
--- a/packages/atlas/CHANGELOG.md
+++ b/packages/atlas/CHANGELOG.md
@@ -1,5 +1,11 @@
 # atlas
 
+# v0.1.0 (2019-10-08)
+
+- Add `zIndex` to `Marker`
+- Remove dependency on `meta`
+- Add `==` and `hashCode` overrides to `MarkerIcon`
+
 # v0.0.8 (2019-8-22)
 
 - Refactor to include `AtlasController`

--- a/packages/atlas/lib/src/camera_position.dart
+++ b/packages/atlas/lib/src/camera_position.dart
@@ -1,5 +1,5 @@
-import 'package:meta/meta.dart';
 import 'package:atlas/atlas.dart';
+import 'package:flutter/foundation.dart';
 
 /// The `CameraPosition` represents the position of the map "camera",
 /// the view point from which the world is shown in the map view.

--- a/packages/atlas/lib/src/lat_lng.dart
+++ b/packages/atlas/lib/src/lat_lng.dart
@@ -1,4 +1,4 @@
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart';
 
 /// A pair of latitude and longitude coordinates.
 /// The `latitude` and `longitude` are stored as degrees.

--- a/packages/atlas/lib/src/lat_lng_bounds.dart
+++ b/packages/atlas/lib/src/lat_lng_bounds.dart
@@ -1,5 +1,5 @@
+import 'package:flutter/foundation.dart';
 import 'package:atlas/atlas.dart';
-import 'package:meta/meta.dart';
 
 /// A latitude/longitude aligned rectangle.
 ///
@@ -13,7 +13,9 @@ class LatLngBounds {
   final LatLng northeast;
   final LatLng southwest;
 
-  LatLngBounds({@required this.northeast, @required this.southwest})
-      : assert(northeast != null),
+  const LatLngBounds({
+    @required this.northeast,
+    @required this.southwest,
+  })  : assert(northeast != null),
         assert(southwest != null);
 }

--- a/packages/atlas/lib/src/marker.dart
+++ b/packages/atlas/lib/src/marker.dart
@@ -1,4 +1,4 @@
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart';
 import 'package:atlas/atlas.dart';
 
 /// Marks a geographical location on the map.
@@ -15,11 +15,18 @@ class Marker {
   /// A `void Function` which is called whenever a `Marker` is tapped.
   final void Function() onTap;
 
+  /// The z-index of the marker, used to determine relative drawing order of
+  /// map overlays.
+  ///
+  /// Lower values means drawn earlier, and thus appearing to be closer to the surface of the Earth.
+  final double zIndex;
+
   const Marker({
     @required this.id,
     @required this.position,
     this.onTap,
     this.icon,
+    this.zIndex = 0.0,
   })  : assert(id != null),
         assert(position != null);
 
@@ -28,9 +35,13 @@ class Marker {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
     final Marker typedOther = other;
-    return id == typedOther.id && position == typedOther.position;
+    return id == typedOther.id &&
+        position == typedOther.position &&
+        icon == typedOther.icon &&
+        zIndex == typedOther.zIndex;
   }
 
   @override
-  int get hashCode => id.hashCode ^ position.hashCode;
+  int get hashCode =>
+      id.hashCode ^ position.hashCode ^ icon.hashCode ^ zIndex.hashCode;
 }

--- a/packages/atlas/lib/src/marker_icon.dart
+++ b/packages/atlas/lib/src/marker_icon.dart
@@ -1,4 +1,4 @@
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart';
 
 /// Optional Marker icon.
 class MarkerIcon {
@@ -9,4 +9,15 @@ class MarkerIcon {
   const MarkerIcon({
     @required this.assetName,
   }) : assert(assetName != null);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+    final MarkerIcon typedOther = other;
+    return assetName == typedOther.assetName;
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode ^ assetName.hashCode;
 }

--- a/packages/atlas/pubspec.yaml
+++ b/packages/atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atlas
 description: An extensible map abstraction for Flutter with support for multiple map providers
-version: 0.0.8
+version: 0.1.0
 authors:
   - Jorge Coca <jcocaramos@gmail.com>
   - Felix Angelov <felangelov@gmail.com>
@@ -16,7 +16,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.1.6
 
 dev_dependencies:
   flutter_test:

--- a/packages/atlas/test/marker_icon_test.dart
+++ b/packages/atlas/test/marker_icon_test.dart
@@ -13,5 +13,26 @@ main() {
         expect(error, isAssertionError);
       }
     });
+
+    test('should override == properly', () {
+      expect(
+        MarkerIcon(
+          assetName: 'my-asset',
+        ),
+        MarkerIcon(
+          assetName: 'my-asset',
+        ),
+      );
+    });
+
+    test('should override hashCode properly', () {
+      final markerIcon = MarkerIcon(
+        assetName: 'my-asset',
+      );
+      expect(
+        markerIcon.hashCode,
+        markerIcon.runtimeType.hashCode ^ markerIcon.assetName.hashCode,
+      );
+    });
   });
 }

--- a/packages/atlas/test/marker_test.dart
+++ b/packages/atlas/test/marker_test.dart
@@ -44,6 +44,45 @@ main() {
       expect(marker.onTap, expectedOnTap);
     });
 
+    test('should have correct properties when no zIndex is provided', () {
+      final expectedId = 'id';
+      final expectedPosition = LatLng(
+        latitude: 37.42796133580664,
+        longitude: -122.085749655962,
+      );
+      final expectedOnTap = null;
+      final expectedZIndex = 0.0;
+      final marker = Marker(
+        id: expectedId,
+        position: expectedPosition,
+        onTap: expectedOnTap,
+      );
+      expect(marker.id, expectedId);
+      expect(marker.position, expectedPosition);
+      expect(marker.onTap, expectedOnTap);
+      expect(marker.zIndex, expectedZIndex);
+    });
+
+    test('should have correct properties when zIndex is provided', () {
+      final expectedId = 'id';
+      final expectedPosition = LatLng(
+        latitude: 37.42796133580664,
+        longitude: -122.085749655962,
+      );
+      final expectedOnTap = null;
+      final expectedZIndex = 1.0;
+      final marker = Marker(
+        id: expectedId,
+        position: expectedPosition,
+        onTap: expectedOnTap,
+        zIndex: 1.0,
+      );
+      expect(marker.id, expectedId);
+      expect(marker.position, expectedPosition);
+      expect(marker.onTap, expectedOnTap);
+      expect(marker.zIndex, expectedZIndex);
+    });
+
     test('should have correct properties when onTap is provided', () {
       final expectedId = 'id';
       final expectedPosition = LatLng(
@@ -69,6 +108,7 @@ main() {
           longitude: -122.085749655962,
         ),
         onTap: () {},
+        zIndex: 1.0,
       );
       final marker2 = Marker(
         id: 'id',
@@ -77,6 +117,7 @@ main() {
           longitude: -122.085749655962,
         ),
         onTap: () {},
+        zIndex: 1.0,
       );
       expect(marker1, marker2);
     });


### PR DESCRIPTION
# Atlas v0.1.0

- Add `zIndex` to `Marker`
- Remove dependency on `meta`
- Add `==` and `hashCode` overrides to `MarkerIcon`