### PR TITLE
Feature/support map types

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,6 +22,8 @@ class AtlasSample extends StatefulWidget {
 }
 
 class _AtlasSampleState extends State<AtlasSample> {
+  MapType currentMapType = MapType.normal;
+
   final CameraPosition _initialCameraPosition = CameraPosition(
     target: LatLng(
       latitude: 37.42796133580664,
@@ -77,6 +79,7 @@ class _AtlasSampleState extends State<AtlasSample> {
             markers: _markers,
             showMyLocation: true,
             showMyLocationButton: false,
+            currentMapType: currentMapType,
             onTap: (LatLng position) {
               print(
                 'map tapped: ${position.latitude}, ${position.longitude}',
@@ -124,6 +127,21 @@ class _AtlasSampleState extends State<AtlasSample> {
                       );
                     },
                   ),
+                  Visibility(
+                    visible: _shouldShowMapTypeButton(),
+                    child: FloatingActionButton(
+                            child: Icon(Icons.map),
+                            onPressed: () {
+                              setState(() {
+                                if (currentMapType == MapType.normal) {
+                                  currentMapType = MapType.satellite;
+                                } else {
+                                  currentMapType = MapType.normal;
+                                }
+                              });
+                            },
+                          ),
+                  ),
                 ],
               ),
             ),
@@ -131,5 +149,9 @@ class _AtlasSampleState extends State<AtlasSample> {
         ],
       ),
     );
+  }
+
+  bool _shouldShowMapTypeButton() {
+    return (AtlasProvider.instance.supportedMapTypes.length > 1);
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -130,17 +130,17 @@ class _AtlasSampleState extends State<AtlasSample> {
                   Visibility(
                     visible: _shouldShowMapTypeButton(),
                     child: FloatingActionButton(
-                            child: Icon(Icons.map),
-                            onPressed: () {
-                              setState(() {
-                                if (currentMapType == MapType.normal) {
-                                  currentMapType = MapType.satellite;
-                                } else {
-                                  currentMapType = MapType.normal;
-                                }
-                              });
-                            },
-                          ),
+                      child: Icon(Icons.map),
+                      onPressed: () {
+                        setState(() {
+                          if (currentMapType == MapType.normal) {
+                            currentMapType = MapType.satellite;
+                          } else {
+                            currentMapType = MapType.normal;
+                          }
+                        });
+                      },
+                    ),
                   ),
                 ],
               ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,7 +22,7 @@ class AtlasSample extends StatefulWidget {
 }
 
 class _AtlasSampleState extends State<AtlasSample> {
-  MapType currentMapType = MapType.normal;
+  MapType mapType = MapType.normal;
 
   final CameraPosition _initialCameraPosition = CameraPosition(
     target: LatLng(
@@ -79,7 +79,7 @@ class _AtlasSampleState extends State<AtlasSample> {
             markers: _markers,
             showMyLocation: true,
             showMyLocationButton: false,
-            currentMapType: currentMapType,
+            mapType: mapType,
             onTap: (LatLng position) {
               print(
                 'map tapped: ${position.latitude}, ${position.longitude}',
@@ -133,10 +133,10 @@ class _AtlasSampleState extends State<AtlasSample> {
                       child: Icon(Icons.map),
                       onPressed: () {
                         setState(() {
-                          if (currentMapType == MapType.normal) {
-                            currentMapType = MapType.satellite;
+                          if (mapType == MapType.normal) {
+                            mapType = MapType.satellite;
                           } else {
-                            currentMapType = MapType.normal;
+                            mapType = MapType.normal;
                           }
                         });
                       },
@@ -152,6 +152,6 @@ class _AtlasSampleState extends State<AtlasSample> {
   }
 
   bool _shouldShowMapTypeButton() {
-    return (AtlasProvider.instance.supportedMapTypes.length > 1);
+    return AtlasProvider.instance.supportedMapTypes.length > 1;
   }
 }

--- a/packages/atlas/CHANGELOG.md
+++ b/packages/atlas/CHANGELOG.md
@@ -1,5 +1,12 @@
 # atlas
 
+## v0.5.0 (2020-02-13)
+
+- Added support for `MapType`
+- Added `showTraffic` boolean
+- Added `getScreenCoordinate` to translate from `LatLng`
+- Added `getLatLng` to translate from `ScreenCoordinates`
+
 ## v0.4.0 (2020-01-22)
 
 - Added support for `Polyline` on a Map

--- a/packages/atlas/lib/atlas.dart
+++ b/packages/atlas/lib/atlas.dart
@@ -10,3 +10,4 @@ export 'src/lat_lng.dart';
 export 'src/marker.dart';
 export 'src/provider.dart';
 export 'src/marker_icon.dart';
+export 'src/map_type.dart';

--- a/packages/atlas/lib/src/atlas.dart
+++ b/packages/atlas/lib/src/atlas.dart
@@ -60,6 +60,12 @@ class Atlas extends StatelessWidget {
   ///   * [showMyLocation] parameter.
   final bool showMyLocationButton;
 
+  /// Sets the underlying map type to be displayed.
+  ///
+  /// Defaults to [MapType.normal].
+  ///
+  /// See also:
+  ///   * [Provider.supportedMapTypes] parameter.
   final MapType currentMapType;
 
   Atlas({

--- a/packages/atlas/lib/src/atlas.dart
+++ b/packages/atlas/lib/src/atlas.dart
@@ -60,6 +60,8 @@ class Atlas extends StatelessWidget {
   ///   * [showMyLocation] parameter.
   final bool showMyLocationButton;
 
+  final MapType currentMapType;
+
   Atlas({
     Key key,
     @required this.initialCameraPosition,
@@ -67,6 +69,7 @@ class Atlas extends StatelessWidget {
     Set<Circle> circles,
     bool showMyLocation,
     bool showMyLocationButton,
+    MapType currentMapType,
     this.onTap,
     this.onLongPress,
     this.onMapCreated,
@@ -75,6 +78,7 @@ class Atlas extends StatelessWidget {
         circles = circles ?? Set<Circle>(),
         showMyLocation = showMyLocation ?? false,
         showMyLocationButton = showMyLocationButton ?? false,
+        currentMapType = currentMapType ?? MapType.normal,
         super(key: key);
 
   @override
@@ -87,6 +91,7 @@ class Atlas extends StatelessWidget {
       onLongPress: onLongPress,
       showMyLocation: showMyLocation,
       showMyLocationButton: showMyLocationButton,
+      currentMapType: currentMapType,
       onMapCreated: onMapCreated,
     );
   }

--- a/packages/atlas/lib/src/atlas.dart
+++ b/packages/atlas/lib/src/atlas.dart
@@ -66,7 +66,7 @@ class Atlas extends StatelessWidget {
   ///
   /// See also:
   ///   * [Provider.supportedMapTypes] parameter.
-  final MapType currentMapType;
+  final MapType mapType;
 
   Atlas({
     Key key,
@@ -75,7 +75,7 @@ class Atlas extends StatelessWidget {
     Set<Circle> circles,
     bool showMyLocation,
     bool showMyLocationButton,
-    MapType currentMapType,
+    MapType mapType,
     this.onTap,
     this.onLongPress,
     this.onMapCreated,
@@ -84,7 +84,7 @@ class Atlas extends StatelessWidget {
         circles = circles ?? Set<Circle>(),
         showMyLocation = showMyLocation ?? false,
         showMyLocationButton = showMyLocationButton ?? false,
-        currentMapType = currentMapType ?? MapType.normal,
+        mapType = mapType ?? MapType.normal,
         super(key: key);
 
   @override
@@ -97,7 +97,7 @@ class Atlas extends StatelessWidget {
       onLongPress: onLongPress,
       showMyLocation: showMyLocation,
       showMyLocationButton: showMyLocationButton,
-      currentMapType: currentMapType,
+      mapType: mapType,
       onMapCreated: onMapCreated,
     );
   }

--- a/packages/atlas/lib/src/atlas.dart
+++ b/packages/atlas/lib/src/atlas.dart
@@ -73,7 +73,7 @@ class Atlas extends StatelessWidget {
   /// See also:
   ///   * [Provider.supportedMapTypes] parameter.
   final MapType mapType;
-  
+
   /// Enable real-time traffic information status
   final bool showTraffic;
 

--- a/packages/atlas/lib/src/map_type.dart
+++ b/packages/atlas/lib/src/map_type.dart
@@ -15,6 +15,4 @@ enum MapType {
 
   /// Hybrid tiles (satellite images with some labels/overlays)
   hybrid,
-  
 }
-

--- a/packages/atlas/lib/src/map_type.dart
+++ b/packages/atlas/lib/src/map_type.dart
@@ -1,0 +1,20 @@
+/// Type of map tiles to display.
+
+enum MapType {
+  /// Do not display map tiles.
+  none,
+
+  /// Normal tiles (traffic and labels, subtle terrain information).
+  normal,
+
+  /// Satellite imaging tiles (aerial photos)
+  satellite,
+
+  /// Terrain tiles (indicates type and height of terrain)
+  terrain,
+
+  /// Hybrid tiles (satellite images with some labels/overlays)
+  hybrid,
+  
+}
+

--- a/packages/atlas/lib/src/provider.dart
+++ b/packages/atlas/lib/src/provider.dart
@@ -8,6 +8,13 @@ typedef void ArgumentCallback<T>(T argument);
 /// In order to implement a custom `AtlasProvider` you must simply implement `Provider`
 /// and set your `AtlasProvider.instance` to the instance of your custom `Provider`.
 abstract class Provider {
+
+  /// Allows the respective map provider to declare
+  /// what underlying map types are supported. 
+  /// 
+  /// This info can then be used to either cycle through
+  /// MapTypes with a button on the GUI, or to set the initial
+  /// [Atlas.currentMapType] property. 
   Set<MapType> supportedMapTypes;
 
   Widget build({

--- a/packages/atlas/lib/src/provider.dart
+++ b/packages/atlas/lib/src/provider.dart
@@ -13,7 +13,7 @@ abstract class Provider {
   ///
   /// This info can then be used to either cycle through
   /// MapTypes with a button on the GUI, or to set the initial
-  /// [Atlas.currentMapType] property.
+  /// [Atlas.mapType] property.
   Set<MapType> supportedMapTypes;
 
   Widget build({
@@ -25,6 +25,6 @@ abstract class Provider {
     final ArgumentCallback<AtlasController> onMapCreated,
     final bool showMyLocation,
     final bool showMyLocationButton,
-    final MapType currentMapType,
+    final MapType mapType,
   });
 }

--- a/packages/atlas/lib/src/provider.dart
+++ b/packages/atlas/lib/src/provider.dart
@@ -8,6 +8,8 @@ typedef void ArgumentCallback<T>(T argument);
 /// In order to implement a custom `AtlasProvider` you must simply implement `Provider`
 /// and set your `AtlasProvider.instance` to the instance of your custom `Provider`.
 abstract class Provider {
+  Set<MapType> supportedMapTypes;
+
   Widget build({
     final CameraPosition initialCameraPosition,
     final Set<Marker> markers,
@@ -17,5 +19,6 @@ abstract class Provider {
     final ArgumentCallback<AtlasController> onMapCreated,
     final bool showMyLocation,
     final bool showMyLocationButton,
+    final MapType currentMapType,
   });
 }

--- a/packages/atlas/lib/src/provider.dart
+++ b/packages/atlas/lib/src/provider.dart
@@ -8,13 +8,12 @@ typedef void ArgumentCallback<T>(T argument);
 /// In order to implement a custom `AtlasProvider` you must simply implement `Provider`
 /// and set your `AtlasProvider.instance` to the instance of your custom `Provider`.
 abstract class Provider {
-
   /// Allows the respective map provider to declare
-  /// what underlying map types are supported. 
-  /// 
+  /// what underlying map types are supported.
+  ///
   /// This info can then be used to either cycle through
   /// MapTypes with a button on the GUI, or to set the initial
-  /// [Atlas.currentMapType] property. 
+  /// [Atlas.currentMapType] property.
   Set<MapType> supportedMapTypes;
 
   Widget build({

--- a/packages/atlas/pubspec.yaml
+++ b/packages/atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atlas
 description: An extensible map abstraction for Flutter with support for multiple map providers
-version: 0.4.0
+version: 0.5.0
 authors:
   - Jorge Coca <jcocaramos@gmail.com>
   - Felix Angelov <felangelov@gmail.com>

--- a/packages/atlas/pubspec.yaml
+++ b/packages/atlas/pubspec.yaml
@@ -11,7 +11,7 @@ issue_tracker: https://github.com/bmw-tech/atlas/issues
 homepage: https://bmw-tech.github.io/atlas
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.2.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/packages/atlas/test/atlas_test.dart
+++ b/packages/atlas/test/atlas_test.dart
@@ -49,6 +49,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: false,
         showMyLocationButton: false,
+        currentMapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -67,6 +68,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: false,
           showMyLocationButton: false,
+          currentMapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -93,6 +95,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: false,
         showMyLocationButton: false,
+        currentMapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -112,6 +115,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: false,
           showMyLocationButton: false,
+          currentMapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -125,6 +129,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: false,
         showMyLocationButton: false,
+        currentMapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -143,6 +148,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: false,
           showMyLocationButton: false,
+          currentMapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -167,6 +173,7 @@ main() {
         circles: circles,
         showMyLocation: false,
         showMyLocationButton: false,
+        currentMapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -186,6 +193,7 @@ main() {
           circles: circles,
           showMyLocation: false,
           showMyLocationButton: false,
+          currentMapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -203,6 +211,7 @@ main() {
         onTap: onTap,
         showMyLocation: false,
         showMyLocationButton: false,
+        currentMapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -223,6 +232,7 @@ main() {
           onTap: onTap,
           showMyLocation: false,
           showMyLocationButton: false,
+          currentMapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -240,6 +250,7 @@ main() {
         onLongPress: onLongPress,
         showMyLocation: false,
         showMyLocationButton: false,
+        currentMapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -260,6 +271,7 @@ main() {
           onLongPress: onLongPress,
           showMyLocation: false,
           showMyLocationButton: false,
+          currentMapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -273,6 +285,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: true,
         showMyLocationButton: false,
+        currentMapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -292,6 +305,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: true,
           showMyLocationButton: false,
+          currentMapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -305,6 +319,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: false,
         showMyLocationButton: false,
+        currentMapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -323,6 +338,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: false,
           showMyLocationButton: false,
+          currentMapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -336,6 +352,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: false,
         showMyLocationButton: true,
+        currentMapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -356,6 +373,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: false,
           showMyLocationButton: true,
+          currentMapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -369,6 +387,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: false,
         showMyLocationButton: false,
+        currentMapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -387,6 +406,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: false,
           showMyLocationButton: false,
+          currentMapType: MapType.normal,
         ),
       ).called(1);
     });

--- a/packages/atlas/test/atlas_test.dart
+++ b/packages/atlas/test/atlas_test.dart
@@ -600,7 +600,8 @@ main() {
         polylines: Set<Polyline>(),
         showMyLocation: false,
         showMyLocationButton: false,
-        mapType: MapType.satellite,
+        mapType: MapType.normal,
+        showTraffic: false,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -621,14 +622,39 @@ main() {
           polylines: Set<Polyline>(),
           showMyLocation: false,
           showMyLocationButton: false,
-          mapType: MapType.satellite,
+          mapType: MapType.normal,
+          showTraffic: false,
         ),
       ).called(1);
+    });
 
-      testWidgets(
-          'should call provider build method with correct arguments when showTraffic is enabled',
-          (WidgetTester tester) async {
-        when(provider.build(
+    testWidgets(
+        'should call provider build method with correct arguments when showTraffic is enabled',
+        (WidgetTester tester) async {
+      when(provider.build(
+        initialCameraPosition: initialCameraPosition,
+        markers: Set<Marker>(),
+        circles: Set<Circle>(),
+        polygons: Set<Polygon>(),
+        polylines: Set<Polyline>(),
+        showMyLocation: false,
+        showMyLocationButton: false,
+        mapType: MapType.normal,
+        showTraffic: true,
+      )).thenReturn(Container(key: mapKey));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Atlas(
+              initialCameraPosition: initialCameraPosition,
+              showTraffic: true,
+            ),
+          ),
+        ),
+      );
+      expect(find.byKey(mapKey), findsOneWidget);
+      verify(
+        provider.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           circles: Set<Circle>(),
@@ -638,32 +664,8 @@ main() {
           showMyLocationButton: false,
           mapType: MapType.normal,
           showTraffic: true,
-        )).thenReturn(Container(key: mapKey));
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: Atlas(
-                initialCameraPosition: initialCameraPosition,
-                showTraffic: true,
-              ),
-            ),
-          ),
-        );
-        expect(find.byKey(mapKey), findsOneWidget);
-        verify(
-          provider.build(
-            initialCameraPosition: initialCameraPosition,
-            markers: Set<Marker>(),
-            circles: Set<Circle>(),
-            polygons: Set<Polygon>(),
-            polylines: Set<Polyline>(),
-            showMyLocation: false,
-            showMyLocationButton: false,
-            mapType: MapType.normal,
-            showTraffic: true,
-          ),
-        ).called(1);
-      });
+        ),
+      ).called(1);
     });
   });
 }

--- a/packages/atlas/test/atlas_test.dart
+++ b/packages/atlas/test/atlas_test.dart
@@ -390,5 +390,38 @@ main() {
         ),
       ).called(1);
     });
+
+    testWidgets(
+        'should call provider build method with correct arguments when currentMapType is supplied',
+        (WidgetTester tester) async {
+      when(provider.build(
+        initialCameraPosition: initialCameraPosition,
+        markers: Set<Marker>(),
+        circles: Set<Circle>(),
+        showMyLocation: false,
+        showMyLocationButton: false,
+        currentMapType: MapType.normal,
+      )).thenReturn(Container(key: mapKey));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Atlas(
+              initialCameraPosition: initialCameraPosition,
+            ),
+          ),
+        ),
+      );
+      expect(find.byKey(mapKey), findsOneWidget);
+      verify(
+        provider.build(
+          initialCameraPosition: initialCameraPosition,
+          markers: Set<Marker>(),
+          circles: Set<Circle>(),
+          showMyLocation: false,
+          showMyLocationButton: false,
+          currentMapType: MapType.normal,
+        ),
+      ).called(1);
+    });
   });
 }

--- a/packages/atlas/test/atlas_test.dart
+++ b/packages/atlas/test/atlas_test.dart
@@ -49,7 +49,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: false,
         showMyLocationButton: false,
-        currentMapType: MapType.normal,
+        mapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -68,7 +68,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: false,
           showMyLocationButton: false,
-          currentMapType: MapType.normal,
+          mapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -95,7 +95,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: false,
         showMyLocationButton: false,
-        currentMapType: MapType.normal,
+        mapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -115,7 +115,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: false,
           showMyLocationButton: false,
-          currentMapType: MapType.normal,
+          mapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -129,7 +129,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: false,
         showMyLocationButton: false,
-        currentMapType: MapType.normal,
+        mapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -148,7 +148,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: false,
           showMyLocationButton: false,
-          currentMapType: MapType.normal,
+          mapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -173,7 +173,7 @@ main() {
         circles: circles,
         showMyLocation: false,
         showMyLocationButton: false,
-        currentMapType: MapType.normal,
+        mapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -193,7 +193,7 @@ main() {
           circles: circles,
           showMyLocation: false,
           showMyLocationButton: false,
-          currentMapType: MapType.normal,
+          mapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -211,7 +211,7 @@ main() {
         onTap: onTap,
         showMyLocation: false,
         showMyLocationButton: false,
-        currentMapType: MapType.normal,
+        mapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -232,7 +232,7 @@ main() {
           onTap: onTap,
           showMyLocation: false,
           showMyLocationButton: false,
-          currentMapType: MapType.normal,
+          mapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -250,7 +250,7 @@ main() {
         onLongPress: onLongPress,
         showMyLocation: false,
         showMyLocationButton: false,
-        currentMapType: MapType.normal,
+        mapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -271,7 +271,7 @@ main() {
           onLongPress: onLongPress,
           showMyLocation: false,
           showMyLocationButton: false,
-          currentMapType: MapType.normal,
+          mapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -285,7 +285,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: true,
         showMyLocationButton: false,
-        currentMapType: MapType.normal,
+        mapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -305,7 +305,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: true,
           showMyLocationButton: false,
-          currentMapType: MapType.normal,
+          mapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -319,7 +319,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: false,
         showMyLocationButton: false,
-        currentMapType: MapType.normal,
+        mapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -338,7 +338,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: false,
           showMyLocationButton: false,
-          currentMapType: MapType.normal,
+          mapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -352,7 +352,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: false,
         showMyLocationButton: true,
-        currentMapType: MapType.normal,
+        mapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -373,7 +373,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: false,
           showMyLocationButton: true,
-          currentMapType: MapType.normal,
+          mapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -387,7 +387,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: false,
         showMyLocationButton: false,
-        currentMapType: MapType.normal,
+        mapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -406,13 +406,13 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: false,
           showMyLocationButton: false,
-          currentMapType: MapType.normal,
+          mapType: MapType.normal,
         ),
       ).called(1);
     });
 
     testWidgets(
-        'should call provider build method with correct arguments when currentMapType is supplied',
+        'should call provider build method with correct arguments when mapType is supplied',
         (WidgetTester tester) async {
       when(provider.build(
         initialCameraPosition: initialCameraPosition,
@@ -420,7 +420,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: false,
         showMyLocationButton: false,
-        currentMapType: MapType.normal,
+        mapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -439,7 +439,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: false,
           showMyLocationButton: false,
-          currentMapType: MapType.normal,
+          mapType: MapType.normal,
         ),
       ).called(1);
     });

--- a/packages/atlas/test/atlas_test.dart
+++ b/packages/atlas/test/atlas_test.dart
@@ -625,33 +625,10 @@ main() {
         ),
       ).called(1);
 
-    testWidgets(
-        'should call provider build method with correct arguments when showTraffic is enabled',
-        (WidgetTester tester) async {
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        showMyLocation: false,
-        showMyLocationButton: false,
-        mapType: MapType.normal,
-        showTraffic: true,
-      )).thenReturn(Container(key: mapKey));
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: Atlas(
-              initialCameraPosition: initialCameraPosition,
-              showTraffic: true,
-            ),
-          ),
-        ),
-      );
-      expect(find.byKey(mapKey), findsOneWidget);
-      verify(
-        provider.build(
+      testWidgets(
+          'should call provider build method with correct arguments when showTraffic is enabled',
+          (WidgetTester tester) async {
+        when(provider.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           circles: Set<Circle>(),
@@ -661,8 +638,32 @@ main() {
           showMyLocationButton: false,
           mapType: MapType.normal,
           showTraffic: true,
-        ),
-      ).called(1);
+        )).thenReturn(Container(key: mapKey));
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Atlas(
+                initialCameraPosition: initialCameraPosition,
+                showTraffic: true,
+              ),
+            ),
+          ),
+        );
+        expect(find.byKey(mapKey), findsOneWidget);
+        verify(
+          provider.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            showMyLocation: false,
+            showMyLocationButton: false,
+            mapType: MapType.normal,
+            showTraffic: true,
+          ),
+        ).called(1);
+      });
     });
   });
 }

--- a/packages/atlas/test/atlas_test.dart
+++ b/packages/atlas/test/atlas_test.dart
@@ -248,6 +248,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: false,
         showMyLocationButton: false,
+        mapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -269,6 +270,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: false,
           showMyLocationButton: false,
+          mapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -299,6 +301,7 @@ main() {
         circles: Set<Circle>(),
         showMyLocation: false,
         showMyLocationButton: false,
+        mapType: MapType.normal,
       )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
@@ -320,6 +323,7 @@ main() {
           circles: Set<Circle>(),
           showMyLocation: false,
           showMyLocationButton: false,
+          mapType: MapType.normal,
         ),
       ).called(1);
     });
@@ -568,6 +572,8 @@ main() {
         initialCameraPosition: initialCameraPosition,
         markers: Set<Marker>(),
         circles: Set<Circle>(),
+        polygons: Set<Polygon>(),
+        polylines: Set<Polyline>(),
         showMyLocation: false,
         showMyLocationButton: false,
         mapType: MapType.normal,
@@ -587,6 +593,8 @@ main() {
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           circles: Set<Circle>(),
+          polygons: Set<Polygon>(),
+          polylines: Set<Polyline>(),
           showMyLocation: false,
           showMyLocationButton: false,
           mapType: MapType.normal,

--- a/packages/google_atlas/lib/src/google_atlas.dart
+++ b/packages/google_atlas/lib/src/google_atlas.dart
@@ -92,6 +92,7 @@ class _GoogleMapsProviderState extends State<GoogleMapsProvider> {
           myLocationEnabled: showMyLocation,
           myLocationButtonEnabled: showMyLocationButton,
           mapType: _toGoogleMapType(mapType),
+          trafficEnabled: showTraffic,
           initialCameraPosition:
               CameraUtils.toGoogleCameraPosition(initialCameraPosition),
           markers: snapshot.hasError ? Set<GoogleMaps.Marker>() : snapshot.data,

--- a/packages/google_atlas/lib/src/google_atlas.dart
+++ b/packages/google_atlas/lib/src/google_atlas.dart
@@ -9,12 +9,11 @@ import 'package:google_maps_flutter/google_maps_flutter.dart' as GoogleMaps;
 
 /// `Atlas` Provider for Google Maps
 class GoogleAtlas extends Provider {
-
   @override
   Set<MapType> get supportedMapTypes => {
-      MapType.normal, 
-      MapType.satellite,
-  };
+        MapType.normal,
+        MapType.satellite,
+      };
 
   @override
   Widget build({
@@ -36,7 +35,7 @@ class GoogleAtlas extends Provider {
       currentMapType: currentMapType,
       onTap: onTap,
       onLongPress: onLongPress,
-      onMapCreated: onMapCreated, 
+      onMapCreated: onMapCreated,
     );
   }
 }
@@ -154,9 +153,7 @@ class _GoogleMapsProviderState extends State<GoogleMapsProvider> {
   }
 
   /// Converts an `Atlas.MapType` enum to a `GoogleMaps.MapType` enum.
-  GoogleMaps.MapType _toGoogleMapType(
-    MapType atlasMapType
-  ) {
+  GoogleMaps.MapType _toGoogleMapType(MapType atlasMapType) {
     switch (atlasMapType) {
       case MapType.normal:
         return GoogleMaps.MapType.normal;

--- a/packages/google_atlas/lib/src/google_atlas.dart
+++ b/packages/google_atlas/lib/src/google_atlas.dart
@@ -9,12 +9,21 @@ import 'package:google_maps_flutter/google_maps_flutter.dart' as GoogleMaps;
 
 /// `Atlas` Provider for Google Maps
 class GoogleAtlas extends Provider {
+
+  @override
+  Set<MapType> get supportedMapTypes => {
+      MapType.normal, 
+      MapType.satellite,
+  };
+
   @override
   Widget build({
     @required CameraPosition initialCameraPosition,
     @required Set<Marker> markers,
+    @required Set<Circle> circles,
     @required bool showMyLocation,
     @required bool showMyLocationButton,
+    @required MapType currentMapType,
     ArgumentCallback<LatLng> onTap,
     ArgumentCallback<LatLng> onLongPress,
     ArgumentCallback<AtlasController> onMapCreated,
@@ -24,9 +33,10 @@ class GoogleAtlas extends Provider {
       markers: markers,
       showMyLocation: showMyLocation,
       showMyLocationButton: showMyLocationButton,
+      currentMapType: currentMapType,
       onTap: onTap,
       onLongPress: onLongPress,
-      onMapCreated: onMapCreated,
+      onMapCreated: onMapCreated, 
     );
   }
 }
@@ -36,6 +46,7 @@ class GoogleMapsProvider extends StatefulWidget {
   final Set<Marker> markers;
   final bool showMyLocation;
   final bool showMyLocationButton;
+  final MapType currentMapType;
   final ArgumentCallback<LatLng> onTap;
   final ArgumentCallback<LatLng> onLongPress;
   final ArgumentCallback<AtlasController> onMapCreated;
@@ -45,6 +56,7 @@ class GoogleMapsProvider extends StatefulWidget {
     @required this.markers,
     @required this.showMyLocation,
     @required this.showMyLocationButton,
+    @required this.currentMapType,
     this.onTap,
     this.onLongPress,
     this.onMapCreated,
@@ -58,6 +70,7 @@ class _GoogleMapsProviderState extends State<GoogleMapsProvider> {
   Set<Marker> get markers => widget.markers;
   bool get showMyLocation => widget.showMyLocation;
   bool get showMyLocationButton => widget.showMyLocationButton;
+  MapType get currentMapType => widget.currentMapType;
   ArgumentCallback<LatLng> get onTap => widget.onTap;
   ArgumentCallback<LatLng> get onLongPress => widget.onLongPress;
   ArgumentCallback<AtlasController> get onMapCreated => widget.onMapCreated;
@@ -71,7 +84,7 @@ class _GoogleMapsProviderState extends State<GoogleMapsProvider> {
         return GoogleMaps.GoogleMap(
           myLocationEnabled: showMyLocation,
           myLocationButtonEnabled: showMyLocationButton,
-          mapType: GoogleMaps.MapType.normal,
+          mapType: _toGoogleMapType(currentMapType),
           initialCameraPosition:
               CameraUtils.toGoogleCameraPosition(initialCameraPosition),
           markers: snapshot.hasError ? Set<GoogleMaps.Marker>() : snapshot.data,
@@ -138,6 +151,28 @@ class _GoogleMapsProviderState extends State<GoogleMapsProvider> {
     return (GoogleMaps.LatLng position) {
       onLongPress?.call(LatLngUtils.fromGoogleLatLng(position));
     };
+  }
+
+  /// Converts an `Atlas.MapType` enum to a `GoogleMaps.MapType` enum.
+  GoogleMaps.MapType _toGoogleMapType(
+    MapType atlasMapType
+  ) {
+    switch (atlasMapType) {
+      case MapType.normal:
+        return GoogleMaps.MapType.normal;
+        break;
+      case MapType.satellite:
+        return GoogleMaps.MapType.satellite;
+        break;
+      case MapType.hybrid:
+        return GoogleMaps.MapType.hybrid;
+        break;
+      case MapType.terrain:
+        return GoogleMaps.MapType.terrain;
+        break;
+      default:
+        return GoogleMaps.MapType.normal;
+    }
   }
 
   /// Callback method where GoogleMaps passes the map controller

--- a/packages/google_atlas/lib/src/google_atlas.dart
+++ b/packages/google_atlas/lib/src/google_atlas.dart
@@ -13,6 +13,7 @@ class GoogleAtlas extends Provider {
   Set<MapType> get supportedMapTypes => {
         MapType.normal,
         MapType.satellite,
+        MapType.terrain,
       };
 
   @override
@@ -22,7 +23,7 @@ class GoogleAtlas extends Provider {
     @required Set<Circle> circles,
     @required bool showMyLocation,
     @required bool showMyLocationButton,
-    @required MapType currentMapType,
+    @required MapType mapType,
     ArgumentCallback<LatLng> onTap,
     ArgumentCallback<LatLng> onLongPress,
     ArgumentCallback<AtlasController> onMapCreated,
@@ -32,7 +33,7 @@ class GoogleAtlas extends Provider {
       markers: markers,
       showMyLocation: showMyLocation,
       showMyLocationButton: showMyLocationButton,
-      currentMapType: currentMapType,
+      mapType: mapType,
       onTap: onTap,
       onLongPress: onLongPress,
       onMapCreated: onMapCreated,
@@ -45,7 +46,7 @@ class GoogleMapsProvider extends StatefulWidget {
   final Set<Marker> markers;
   final bool showMyLocation;
   final bool showMyLocationButton;
-  final MapType currentMapType;
+  final MapType mapType;
   final ArgumentCallback<LatLng> onTap;
   final ArgumentCallback<LatLng> onLongPress;
   final ArgumentCallback<AtlasController> onMapCreated;
@@ -55,7 +56,7 @@ class GoogleMapsProvider extends StatefulWidget {
     @required this.markers,
     @required this.showMyLocation,
     @required this.showMyLocationButton,
-    @required this.currentMapType,
+    @required this.mapType,
     this.onTap,
     this.onLongPress,
     this.onMapCreated,
@@ -69,7 +70,7 @@ class _GoogleMapsProviderState extends State<GoogleMapsProvider> {
   Set<Marker> get markers => widget.markers;
   bool get showMyLocation => widget.showMyLocation;
   bool get showMyLocationButton => widget.showMyLocationButton;
-  MapType get currentMapType => widget.currentMapType;
+  MapType get mapType => widget.mapType;
   ArgumentCallback<LatLng> get onTap => widget.onTap;
   ArgumentCallback<LatLng> get onLongPress => widget.onLongPress;
   ArgumentCallback<AtlasController> get onMapCreated => widget.onMapCreated;
@@ -83,7 +84,7 @@ class _GoogleMapsProviderState extends State<GoogleMapsProvider> {
         return GoogleMaps.GoogleMap(
           myLocationEnabled: showMyLocation,
           myLocationButtonEnabled: showMyLocationButton,
-          mapType: _toGoogleMapType(currentMapType),
+          mapType: _toGoogleMapType(mapType),
           initialCameraPosition:
               CameraUtils.toGoogleCameraPosition(initialCameraPosition),
           markers: snapshot.hasError ? Set<GoogleMaps.Marker>() : snapshot.data,

--- a/packages/google_atlas/lib/src/google_atlas.dart
+++ b/packages/google_atlas/lib/src/google_atlas.dart
@@ -9,7 +9,6 @@ import 'package:google_maps_flutter/google_maps_flutter.dart' as GoogleMaps;
 
 /// `Atlas` Provider for Google Maps
 class GoogleAtlas extends Provider {
-  @override
   Set<MapType> get supportedMapTypes => {
         MapType.normal,
         MapType.satellite,
@@ -21,6 +20,8 @@ class GoogleAtlas extends Provider {
     @required CameraPosition initialCameraPosition,
     @required Set<Marker> markers,
     @required Set<Circle> circles,
+    @required Set<Polygon> polygons,
+    @required Set<Polyline> polylines,
     @required bool showMyLocation,
     @required bool showMyLocationButton,
     @required MapType mapType,

--- a/packages/google_atlas/lib/src/google_atlas.dart
+++ b/packages/google_atlas/lib/src/google_atlas.dart
@@ -9,6 +9,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart' as GoogleMaps;
 
 /// `Atlas` Provider for Google Maps
 class GoogleAtlas extends Provider {
+  @override
   Set<MapType> get supportedMapTypes => {
         MapType.normal,
         MapType.satellite,

--- a/packages/google_atlas/lib/src/google_atlas.dart
+++ b/packages/google_atlas/lib/src/google_atlas.dart
@@ -26,6 +26,7 @@ class GoogleAtlas extends Provider {
     @required bool showMyLocation,
     @required bool showMyLocationButton,
     @required MapType mapType,
+    @required bool showTraffic,
     ArgumentCallback<LatLng> onTap,
     ArgumentCallback<LatLng> onLongPress,
     ArgumentCallback<AtlasController> onMapCreated,
@@ -36,6 +37,7 @@ class GoogleAtlas extends Provider {
       showMyLocation: showMyLocation,
       showMyLocationButton: showMyLocationButton,
       mapType: mapType,
+      showTraffic: showTraffic,
       onTap: onTap,
       onLongPress: onLongPress,
       onMapCreated: onMapCreated,
@@ -49,6 +51,7 @@ class GoogleMapsProvider extends StatefulWidget {
   final bool showMyLocation;
   final bool showMyLocationButton;
   final MapType mapType;
+  final bool showTraffic;
   final ArgumentCallback<LatLng> onTap;
   final ArgumentCallback<LatLng> onLongPress;
   final ArgumentCallback<AtlasController> onMapCreated;
@@ -59,6 +62,7 @@ class GoogleMapsProvider extends StatefulWidget {
     @required this.showMyLocation,
     @required this.showMyLocationButton,
     @required this.mapType,
+    @required this.showTraffic,
     this.onTap,
     this.onLongPress,
     this.onMapCreated,
@@ -73,6 +77,7 @@ class _GoogleMapsProviderState extends State<GoogleMapsProvider> {
   bool get showMyLocation => widget.showMyLocation;
   bool get showMyLocationButton => widget.showMyLocationButton;
   MapType get mapType => widget.mapType;
+  bool get showTraffic => widget.showTraffic;
   ArgumentCallback<LatLng> get onTap => widget.onTap;
   ArgumentCallback<LatLng> get onLongPress => widget.onLongPress;
   ArgumentCallback<AtlasController> get onMapCreated => widget.onMapCreated;

--- a/packages/google_atlas/lib/src/google_atlas_controller.dart
+++ b/packages/google_atlas/lib/src/google_atlas_controller.dart
@@ -30,4 +30,18 @@ class GoogleAtlasController implements AtlasController {
       ),
     );
   }
+
+  @override
+  Future<LatLng> getLatLng(ScreenCoordinates screenCoordinates) async {
+    var googleLatLng = await _controller
+        .getLatLng(LatLngUtils.toGoogleScreenCoordinate(screenCoordinates));
+    return LatLngUtils.fromGoogleLatLng(googleLatLng);
+  }
+
+  @override
+  Future<ScreenCoordinates> getScreenCoordinate(LatLng latLng) async {
+    var googleScreenCoordinate = await _controller
+        .getScreenCoordinate(LatLngUtils.toGoogleLatLng(latLng));
+    return LatLngUtils.fromGoogleScreenCoordinate(googleScreenCoordinate);
+  }
 }

--- a/packages/google_atlas/lib/src/utils/lat_lng_utils.dart
+++ b/packages/google_atlas/lib/src/utils/lat_lng_utils.dart
@@ -20,4 +20,22 @@ class LatLngUtils {
       longitude: position.longitude,
     );
   }
+
+  /// Converts an `Atlas.ScreenCoordinates` to a `GoogleMaps.ScreenCoordinate`.
+  static GoogleMaps.ScreenCoordinate toGoogleScreenCoordinate(
+      ScreenCoordinates atlasCoordinates) {
+    return GoogleMaps.ScreenCoordinate(
+      x: atlasCoordinates.x,
+      y: atlasCoordinates.y,
+    );
+  }
+
+  /// Converts a `GoogleMaps.ScreenCoordinate` to an `Atlas.ScreenCoordinates`.
+  static ScreenCoordinates fromGoogleScreenCoordinate(
+      GoogleMaps.ScreenCoordinate googleCoordinate) {
+    return ScreenCoordinates(
+      x: googleCoordinate.x,
+      y: googleCoordinate.y,
+    );
+  }
 }

--- a/packages/google_atlas/pubspec.yaml
+++ b/packages/google_atlas/pubspec.yaml
@@ -16,7 +16,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  atlas: ^0.2.0
+  atlas: 
+    path: "../atlas"
   google_maps_flutter: ^0.5.21+3
 
 dev_dependencies:

--- a/packages/google_atlas/pubspec.yaml
+++ b/packages/google_atlas/pubspec.yaml
@@ -11,7 +11,7 @@ issue_tracker: https://github.com/bmw-tech/atlas/issues
 homepage: https://bmw-tech.github.io/atlas
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.2.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/packages/google_atlas/test/unit_tests/utils/lat_lng_utils_test.dart
+++ b/packages/google_atlas/test/unit_tests/utils/lat_lng_utils_test.dart
@@ -38,5 +38,28 @@ main() {
         expect(result.longitude, -80.0);
       });
     });
+
+    group('toGoogleScreenCoordinate', () {
+      test('returns correct Google Screen Coordinate', () {
+        final result = LatLngUtils.toGoogleScreenCoordinate(ScreenCoordinates(
+          x: 1,
+          y: 2,
+        ));
+        expect(result.x, 1);
+        expect(result.y, 2);
+      });
+    });
+
+    group('fromGoogleScreenCoordinate', () {
+      test('returns correct Atlas Screen Coordinates', () {
+        final result =
+            LatLngUtils.fromGoogleScreenCoordinate(GoogleMaps.ScreenCoordinate(
+          x: 1,
+          y: 2,
+        ));
+        expect(result.x, 1);
+        expect(result.y, 2);
+      });
+    });
   });
 }

--- a/packages/google_atlas/test/widget_tests/fake_maps_controller.dart
+++ b/packages/google_atlas/test/widget_tests/fake_maps_controller.dart
@@ -29,6 +29,8 @@ class FakePlatformGoogleMap {
 
   MapType mapType;
 
+  bool trafficEnabled;
+
   MinMaxZoomPreference minMaxZoomPreference;
 
   bool rotateGesturesEnabled;
@@ -224,6 +226,9 @@ class FakePlatformGoogleMap {
   void updateOptions(Map<dynamic, dynamic> options) {
     if (options.containsKey('compassEnabled')) {
       compassEnabled = options['compassEnabled'];
+    }
+    if (options.containsKey('trafficEnabled')) {
+      trafficEnabled = options['trafficEnabled'];
     }
     if (options.containsKey('cameraTargetBounds')) {
       final List<dynamic> boundsList = options['cameraTargetBounds'];

--- a/packages/google_atlas/test/widget_tests/google_atlas_controller_test.dart
+++ b/packages/google_atlas/test/widget_tests/google_atlas_controller_test.dart
@@ -49,5 +49,48 @@ main() {
         verify(googleMapController.moveCamera(any)).called(1);
       });
     });
+
+    group('getLatLng', () {
+      test('invokes getLatLng', () async {
+        final ScreenCoordinates coordinates = ScreenCoordinates(
+          x: 1,
+          y: 2,
+        );
+        var googleLatLng = GoogleMaps.LatLng(1.1, 2.2);
+
+        when(googleMapController.getLatLng(any))
+            .thenAnswer((_) => Future.value(googleLatLng));
+
+        await googleAtlasController.getLatLng(coordinates);
+        List<dynamic> results =
+            verify(googleMapController.getLatLng(captureAny)).captured;
+        GoogleMaps.ScreenCoordinate resultingScreenCoordinate = results.first;
+        expect(coordinates.x, resultingScreenCoordinate.x);
+        expect(coordinates.y, resultingScreenCoordinate.y);
+      });
+    });
+
+    group('getScreenCoordinate', () {
+      test('invokes getScreenCoordinate', () async {
+        final LatLng inputLatLng = LatLng(
+          latitude: 1.1,
+          longitude: 2.2,
+        );
+        var returnedGoogleScreenCoordinate = GoogleMaps.ScreenCoordinate(
+          x: 1,
+          y: 2,
+        );
+        when(googleMapController.getScreenCoordinate(any))
+            .thenAnswer((_) => Future.value(returnedGoogleScreenCoordinate));
+
+        await googleAtlasController.getScreenCoordinate(inputLatLng);
+        List<dynamic> results =
+            verify(googleMapController.getScreenCoordinate(captureAny))
+                .captured;
+        GoogleMaps.LatLng resultingLatLng = results.first;
+        expect(inputLatLng.latitude, resultingLatLng.latitude);
+        expect(inputLatLng.longitude, resultingLatLng.longitude);
+      });
+    });
   });
 }

--- a/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
+++ b/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
@@ -59,6 +59,85 @@ main() {
     });
 
     testWidgets(
+        'should return correct GoogleMap with currentMapType set to normal type',
+        (WidgetTester tester) async {
+
+      await tester.pumpWidget(MaterialApp(
+        title: 'Atlas Test Sample with Google Provider',
+        home: AtlasTestSample(
+          initialCameraPosition: initialCameraPosition,
+          currentMapType: MapType.normal,
+        ),
+      ));
+
+      await tester.pumpAndSettle();
+
+      final FakePlatformGoogleMap platformGoogleMap =
+          fakePlatformViewsController.lastCreatedView;
+
+      expect(platformGoogleMap.mapType, GoogleMaps.MapType.normal);
+    });
+    
+    testWidgets(
+        'should return correct GoogleMap with currentMapType set to satellite type',
+        (WidgetTester tester) async {
+
+      await tester.pumpWidget(MaterialApp(
+        title: 'Atlas Test Sample with Google Provider',
+        home: AtlasTestSample(
+          initialCameraPosition: initialCameraPosition,
+          currentMapType: MapType.satellite,
+        ),
+      ));
+
+      await tester.pumpAndSettle();
+
+      final FakePlatformGoogleMap platformGoogleMap =
+          fakePlatformViewsController.lastCreatedView;
+
+      expect(platformGoogleMap.mapType, GoogleMaps.MapType.satellite);
+    });
+
+    testWidgets(
+        'should return correct GoogleMap with currentMapType set to terrain type',
+        (WidgetTester tester) async {
+
+      await tester.pumpWidget(MaterialApp(
+        title: 'Atlas Test Sample with Google Provider',
+        home: AtlasTestSample(
+          initialCameraPosition: initialCameraPosition,
+          currentMapType: MapType.terrain,
+        ),
+      ));
+
+      await tester.pumpAndSettle();
+
+      final FakePlatformGoogleMap platformGoogleMap =
+          fakePlatformViewsController.lastCreatedView;
+
+      expect(platformGoogleMap.mapType, GoogleMaps.MapType.terrain);
+    });
+
+    testWidgets(
+        'should return correct GoogleMap with currentMapType set to hybrid type',
+        (WidgetTester tester) async {
+
+      await tester.pumpWidget(MaterialApp(
+        title: 'Atlas Test Sample with Google Provider',
+        home: AtlasTestSample(
+          initialCameraPosition: initialCameraPosition,
+          currentMapType: MapType.hybrid,
+        ),
+      ));
+
+      await tester.pumpAndSettle();
+
+      final FakePlatformGoogleMap platformGoogleMap =
+          fakePlatformViewsController.lastCreatedView;
+
+      expect(platformGoogleMap.mapType, GoogleMaps.MapType.hybrid);
+    });
+    testWidgets(
         'should return correct GoogleMap when build is called one marker',
         (WidgetTester tester) async {
       final GoogleMaps.Marker expectedMarker = GoogleMaps.Marker(
@@ -482,6 +561,7 @@ class AtlasTestSample extends StatefulWidget {
   final Set<Marker> markers;
   final bool showMyLocation;
   final bool showMyLocationButton;
+  final MapType currentMapType;
   final ArgumentCallback<LatLng> onTap;
   final ArgumentCallback<LatLng> onLongPress;
 
@@ -490,6 +570,7 @@ class AtlasTestSample extends StatefulWidget {
     this.markers,
     this.showMyLocation,
     this.showMyLocationButton,
+    this.currentMapType,
     this.onTap,
     this.onLongPress,
   });
@@ -499,6 +580,7 @@ class AtlasTestSample extends StatefulWidget {
         markers: this.markers,
         showMyLocation: this.showMyLocation,
         showMyLocationButton: this.showMyLocationButton,
+        currentMapType: this.currentMapType,
         onTap: this.onTap,
         onLongPress: this.onLongPress,
       );
@@ -509,6 +591,7 @@ class _AtlasTestSampleState extends State<AtlasTestSample> {
   final Set<Marker> markers;
   final bool showMyLocation;
   final bool showMyLocationButton;
+  final MapType currentMapType; 
   final ArgumentCallback<LatLng> onTap;
   final ArgumentCallback<LatLng> onLongPress;
   AtlasController _controller;
@@ -518,6 +601,7 @@ class _AtlasTestSampleState extends State<AtlasTestSample> {
     this.markers,
     this.showMyLocation,
     this.showMyLocationButton,
+    this.currentMapType,
     this.onTap,
     this.onLongPress,
   });
@@ -533,6 +617,7 @@ class _AtlasTestSampleState extends State<AtlasTestSample> {
             markers: this.markers ?? Set(),
             showMyLocation: this.showMyLocation ?? false,
             showMyLocationButton: this.showMyLocationButton ?? false,
+            currentMapType: this.currentMapType ?? MapType.normal,
             onTap: this.onTap ?? null,
             onLongPress: this.onLongPress ?? null,
             onMapCreated: (controller) {

--- a/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
+++ b/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
@@ -61,7 +61,6 @@ main() {
     testWidgets(
         'should return correct GoogleMap with currentMapType set to normal type',
         (WidgetTester tester) async {
-
       await tester.pumpWidget(MaterialApp(
         title: 'Atlas Test Sample with Google Provider',
         home: AtlasTestSample(
@@ -77,11 +76,10 @@ main() {
 
       expect(platformGoogleMap.mapType, GoogleMaps.MapType.normal);
     });
-    
+
     testWidgets(
         'should return correct GoogleMap with currentMapType set to satellite type',
         (WidgetTester tester) async {
-
       await tester.pumpWidget(MaterialApp(
         title: 'Atlas Test Sample with Google Provider',
         home: AtlasTestSample(
@@ -101,7 +99,6 @@ main() {
     testWidgets(
         'should return correct GoogleMap with currentMapType set to terrain type',
         (WidgetTester tester) async {
-
       await tester.pumpWidget(MaterialApp(
         title: 'Atlas Test Sample with Google Provider',
         home: AtlasTestSample(
@@ -121,7 +118,6 @@ main() {
     testWidgets(
         'should return correct GoogleMap with currentMapType set to hybrid type',
         (WidgetTester tester) async {
-
       await tester.pumpWidget(MaterialApp(
         title: 'Atlas Test Sample with Google Provider',
         home: AtlasTestSample(
@@ -591,7 +587,7 @@ class _AtlasTestSampleState extends State<AtlasTestSample> {
   final Set<Marker> markers;
   final bool showMyLocation;
   final bool showMyLocationButton;
-  final MapType currentMapType; 
+  final MapType currentMapType;
   final ArgumentCallback<LatLng> onTap;
   final ArgumentCallback<LatLng> onLongPress;
   AtlasController _controller;

--- a/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
+++ b/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
@@ -59,13 +59,13 @@ main() {
     });
 
     testWidgets(
-        'should return correct GoogleMap with currentMapType set to normal type',
+        'should return correct GoogleMap with mapType set to normal type',
         (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         title: 'Atlas Test Sample with Google Provider',
         home: AtlasTestSample(
           initialCameraPosition: initialCameraPosition,
-          currentMapType: MapType.normal,
+          mapType: MapType.normal,
         ),
       ));
 
@@ -78,13 +78,13 @@ main() {
     });
 
     testWidgets(
-        'should return correct GoogleMap with currentMapType set to satellite type',
+        'should return correct GoogleMap with mapType set to satellite type',
         (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         title: 'Atlas Test Sample with Google Provider',
         home: AtlasTestSample(
           initialCameraPosition: initialCameraPosition,
-          currentMapType: MapType.satellite,
+          mapType: MapType.satellite,
         ),
       ));
 
@@ -97,13 +97,13 @@ main() {
     });
 
     testWidgets(
-        'should return correct GoogleMap with currentMapType set to terrain type',
+        'should return correct GoogleMap with mapType set to terrain type',
         (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         title: 'Atlas Test Sample with Google Provider',
         home: AtlasTestSample(
           initialCameraPosition: initialCameraPosition,
-          currentMapType: MapType.terrain,
+          mapType: MapType.terrain,
         ),
       ));
 
@@ -116,13 +116,13 @@ main() {
     });
 
     testWidgets(
-        'should return correct GoogleMap with currentMapType set to hybrid type',
+        'should return correct GoogleMap with mapType set to hybrid type',
         (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         title: 'Atlas Test Sample with Google Provider',
         home: AtlasTestSample(
           initialCameraPosition: initialCameraPosition,
-          currentMapType: MapType.hybrid,
+          mapType: MapType.hybrid,
         ),
       ));
 
@@ -557,7 +557,7 @@ class AtlasTestSample extends StatefulWidget {
   final Set<Marker> markers;
   final bool showMyLocation;
   final bool showMyLocationButton;
-  final MapType currentMapType;
+  final MapType mapType;
   final ArgumentCallback<LatLng> onTap;
   final ArgumentCallback<LatLng> onLongPress;
 
@@ -566,7 +566,7 @@ class AtlasTestSample extends StatefulWidget {
     this.markers,
     this.showMyLocation,
     this.showMyLocationButton,
-    this.currentMapType,
+    this.mapType,
     this.onTap,
     this.onLongPress,
   });
@@ -576,7 +576,7 @@ class AtlasTestSample extends StatefulWidget {
         markers: this.markers,
         showMyLocation: this.showMyLocation,
         showMyLocationButton: this.showMyLocationButton,
-        currentMapType: this.currentMapType,
+        mapType: this.mapType,
         onTap: this.onTap,
         onLongPress: this.onLongPress,
       );
@@ -587,7 +587,7 @@ class _AtlasTestSampleState extends State<AtlasTestSample> {
   final Set<Marker> markers;
   final bool showMyLocation;
   final bool showMyLocationButton;
-  final MapType currentMapType;
+  final MapType mapType;
   final ArgumentCallback<LatLng> onTap;
   final ArgumentCallback<LatLng> onLongPress;
   AtlasController _controller;
@@ -597,7 +597,7 @@ class _AtlasTestSampleState extends State<AtlasTestSample> {
     this.markers,
     this.showMyLocation,
     this.showMyLocationButton,
-    this.currentMapType,
+    this.mapType,
     this.onTap,
     this.onLongPress,
   });
@@ -613,7 +613,7 @@ class _AtlasTestSampleState extends State<AtlasTestSample> {
             markers: this.markers ?? Set(),
             showMyLocation: this.showMyLocation ?? false,
             showMyLocationButton: this.showMyLocationButton ?? false,
-            currentMapType: this.currentMapType ?? MapType.normal,
+            mapType: this.mapType ?? MapType.normal,
             onTap: this.onTap ?? null,
             onLongPress: this.onLongPress ?? null,
             onMapCreated: (controller) {

--- a/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
+++ b/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
@@ -17,6 +17,19 @@ main() {
         fakePlatformViewsController.fakePlatformViewsMethodHandler);
   });
 
+  group('GoogleAtlasProvider Test', () {
+    Provider provider;
+
+    setUp(() {
+      provider = GoogleAtlasProviderSample();
+    });
+
+    test('provider creates and supplies maptypes', () {
+      expect(provider.supportedMapTypes,
+          {MapType.normal, MapType.satellite, MapType.terrain});
+    });
+  });
+
   group('GoogleAtlas Widget Test', () {
     GoogleAtlas googleAtlas;
     CameraPosition initialCameraPosition;
@@ -567,6 +580,40 @@ main() {
       expect(platformGoogleMap.cameraPosition.target, expectedPosition);
     });
   });
+}
+
+class GoogleAtlasProviderSample extends Provider {
+  @override
+  Set<MapType> get supportedMapTypes => {
+        MapType.normal,
+        MapType.satellite,
+        MapType.terrain,
+      };
+  @override
+  Widget build(
+      {CameraPosition initialCameraPosition,
+      Set<Marker> markers,
+      Set<Circle> circles,
+      Set<Polygon> polygons,
+      Set<Polyline> polylines,
+      ArgumentCallback<LatLng> onTap,
+      ArgumentCallback<LatLng> onLongPress,
+      ArgumentCallback<AtlasController> onMapCreated,
+      bool showMyLocation,
+      bool showMyLocationButton,
+      MapType mapType,
+      bool showTraffic}) {
+    return AtlasTestSample(
+      initialCameraPosition: initialCameraPosition,
+      markers: markers,
+      showMyLocation: showMyLocation,
+      showMyLocationButton: showMyLocationButton,
+      mapType: mapType,
+      showTraffic: showTraffic,
+      onTap: onTap,
+      onLongPress: onLongPress,
+    );
+  }
 }
 
 class AtlasTestSample extends StatefulWidget {

--- a/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
+++ b/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
@@ -58,6 +58,23 @@ main() {
       expect(platformGoogleMap.mapType, GoogleMaps.MapType.normal);
     });
 
+    testWidgets('should return correct GoogleMap with showTraffic set to true',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        title: 'Atlas Test Sample with Google Provider',
+        home: AtlasTestSample(
+          initialCameraPosition: initialCameraPosition,
+          showTraffic: true,
+        ),
+      ));
+
+      await tester.pumpAndSettle();
+
+      final FakePlatformGoogleMap platformGoogleMap =
+          fakePlatformViewsController.lastCreatedView;
+
+      expect(platformGoogleMap.trafficEnabled, true);
+    });
     testWidgets(
         'should return correct GoogleMap with mapType set to normal type',
         (WidgetTester tester) async {
@@ -558,6 +575,7 @@ class AtlasTestSample extends StatefulWidget {
   final bool showMyLocation;
   final bool showMyLocationButton;
   final MapType mapType;
+  final bool showTraffic;
   final ArgumentCallback<LatLng> onTap;
   final ArgumentCallback<LatLng> onLongPress;
 
@@ -567,6 +585,7 @@ class AtlasTestSample extends StatefulWidget {
     this.showMyLocation,
     this.showMyLocationButton,
     this.mapType,
+    this.showTraffic,
     this.onTap,
     this.onLongPress,
   });
@@ -577,6 +596,7 @@ class AtlasTestSample extends StatefulWidget {
         showMyLocation: this.showMyLocation,
         showMyLocationButton: this.showMyLocationButton,
         mapType: this.mapType,
+        showTraffic: this.showTraffic,
         onTap: this.onTap,
         onLongPress: this.onLongPress,
       );
@@ -588,6 +608,7 @@ class _AtlasTestSampleState extends State<AtlasTestSample> {
   final bool showMyLocation;
   final bool showMyLocationButton;
   final MapType mapType;
+  final bool showTraffic;
   final ArgumentCallback<LatLng> onTap;
   final ArgumentCallback<LatLng> onLongPress;
   AtlasController _controller;
@@ -598,6 +619,7 @@ class _AtlasTestSampleState extends State<AtlasTestSample> {
     this.showMyLocation,
     this.showMyLocationButton,
     this.mapType,
+    this.showTraffic,
     this.onTap,
     this.onLongPress,
   });
@@ -614,6 +636,7 @@ class _AtlasTestSampleState extends State<AtlasTestSample> {
             showMyLocation: this.showMyLocation ?? false,
             showMyLocationButton: this.showMyLocationButton ?? false,
             mapType: this.mapType ?? MapType.normal,
+            showTraffic: this.showTraffic ?? false,
             onTap: this.onTap ?? null,
             onLongPress: this.onLongPress ?? null,
             onMapCreated: (controller) {


### PR DESCRIPTION
This pull request adds the ability for a map provider to declare what map types it supports, using `Provider.supportedMapTypes`.

The current options are: 
`MapType`
- `.normal`
- `.satellite`
- `.terrain`
- `.hybrid`

Based on that, Atlas will now allow the client to set what `MapType` it should display with `Atlas.currentMapType`. 

![MapTypeSwitching](https://user-images.githubusercontent.com/944837/72713740-db017000-3b6d-11ea-9b34-3dcd5cdaf889.gif)
