### PR TITLE
Added ScreenCordinates 

### DIFF
--- a/packages/atlas/lib/atlas.dart
+++ b/packages/atlas/lib/atlas.dart
@@ -12,3 +12,4 @@ export 'src/provider.dart';
 export 'src/marker_icon.dart';
 export 'src/polygon.dart';
 export 'src/polyline.dart';
+export 'src/screen_coordinate.dart';

--- a/packages/atlas/lib/src/atlas_controller.dart
+++ b/packages/atlas/lib/src/atlas_controller.dart
@@ -10,4 +10,10 @@ abstract class AtlasController {
   /// Updates the camera bounds based on the provided `LatLngBounds`
   /// and adds padding around the bounds based on the provided `padding`.
   Future<void> updateBounds(LatLngBounds bounds, double padding);
+
+  /// Return a [ScreenCoordinate] corresponding to the [LatLng] in the map view.
+  Future<LatLng> getLatLng(ScreenCoordinate screenCoordinates);
+
+  /// Returns a [LatLng] corresponding to the [ScreenCoordinate] in the map view.
+  Future<ScreenCoordinate> getScreenCoordinate(LatLng latLng);
 }

--- a/packages/atlas/lib/src/atlas_controller.dart
+++ b/packages/atlas/lib/src/atlas_controller.dart
@@ -12,8 +12,8 @@ abstract class AtlasController {
   Future<void> updateBounds(LatLngBounds bounds, double padding);
 
   /// Return a [ScreenCoordinate] corresponding to the [LatLng] in the map view.
-  Future<LatLng> getLatLng(ScreenCoordinate screenCoordinates);
+  Future<LatLng> getLatLng(ScreenCoordinates screenCoordinates);
 
   /// Returns a [LatLng] corresponding to the [ScreenCoordinate] in the map view.
-  Future<ScreenCoordinate> getScreenCoordinate(LatLng latLng);
+  Future<ScreenCoordinates> getScreenCoordinate(LatLng latLng);
 }

--- a/packages/atlas/lib/src/screen_coordinate.dart
+++ b/packages/atlas/lib/src/screen_coordinate.dart
@@ -20,5 +20,6 @@ class ScreenCoordinate {
     return o is ScreenCoordinate && o.x == x && o.y == y;
   }
 
+  @override
   int get hashcode => runtimeType.hashCode ^ x.hashCode ^ y.hashCode;
 }

--- a/packages/atlas/lib/src/screen_coordinate.dart
+++ b/packages/atlas/lib/src/screen_coordinate.dart
@@ -13,16 +13,6 @@ class ScreenCoordinate {
   const ScreenCoordinate({
     @required this.x,
     @required this.y,
-  });
-
-  @override
-  bool operator ==(Object o) {
-    if (identical(this, o)) return true;
-    if (o.runtimeType != runtimeType) return false;
-    final ScreenCoordinate typedOther = o;
-    return x == typedOther.x && y == typedOther.y;
-  }
-
-  @override
-  int get hashCode => runtimeType.hashCode ^ x.hashCode ^ y.hashCode;
+  })  : assert(x != null),
+        assert(y != null);
 }

--- a/packages/atlas/lib/src/screen_coordinate.dart
+++ b/packages/atlas/lib/src/screen_coordinate.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/rendering.dart';
 
 /// A pair of x and y coordinates.
 /// The `x` and `y` coordinates are stored as screen pixels (not display pixels)

--- a/packages/atlas/lib/src/screen_coordinate.dart
+++ b/packages/atlas/lib/src/screen_coordinate.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/foundation.dart';
+/// A pair of x and y coordinates.
+/// The `x` and `y` coordinates are stored as screen pixels (not display pixels)
+/// relative to the top of the map, not top left of the whole screen.
+class ScreenCoordinate {
+  /// The x coordinate in screen pixels.
+  final int x;
+
+  /// The y coordinate in screen pixels.
+  final int y;
+
+  const ScreenCoordinate({
+    @required this.x,
+    @required this.y,
+  });
+
+  @override
+  bool operator == (Object o) {
+    return o is ScreenCoordinate && o.x == x && o.y == y;
+  }
+
+  int get hashcode =>
+      runtimeType.hashCode ^ x.hashCode ^ y.hashCode;
+}

--- a/packages/atlas/lib/src/screen_coordinate.dart
+++ b/packages/atlas/lib/src/screen_coordinate.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+
 /// A pair of x and y coordinates.
 /// The `x` and `y` coordinates are stored as screen pixels (not display pixels)
 /// relative to the top of the map, not top left of the whole screen.
@@ -15,10 +16,9 @@ class ScreenCoordinate {
   });
 
   @override
-  bool operator == (Object o) {
+  bool operator ==(Object o) {
     return o is ScreenCoordinate && o.x == x && o.y == y;
   }
 
-  int get hashcode =>
-      runtimeType.hashCode ^ x.hashCode ^ y.hashCode;
+  int get hashcode => runtimeType.hashCode ^ x.hashCode ^ y.hashCode;
 }

--- a/packages/atlas/lib/src/screen_coordinate.dart
+++ b/packages/atlas/lib/src/screen_coordinate.dart
@@ -17,9 +17,13 @@ class ScreenCoordinate {
 
   @override
   bool operator ==(Object o) {
-    return o is ScreenCoordinate && o.x == x && o.y == y;
+    if(identical(this, o)) return true;
+    if(o.runtimeType != runtimeType) return false;
+    final ScreenCoordinate typedOther = o;
+    return x == typedOther.x &&
+        y == typedOther.y;
   }
 
   @override
-  int get hashcode => runtimeType.hashCode ^ x.hashCode ^ y.hashCode;
+  int get hashCode => runtimeType.hashCode ^ x.hashCode ^ y.hashCode;
 }

--- a/packages/atlas/lib/src/screen_coordinate.dart
+++ b/packages/atlas/lib/src/screen_coordinate.dart
@@ -17,11 +17,10 @@ class ScreenCoordinate {
 
   @override
   bool operator ==(Object o) {
-    if(identical(this, o)) return true;
-    if(o.runtimeType != runtimeType) return false;
+    if (identical(this, o)) return true;
+    if (o.runtimeType != runtimeType) return false;
     final ScreenCoordinate typedOther = o;
-    return x == typedOther.x &&
-        y == typedOther.y;
+    return x == typedOther.x && y == typedOther.y;
   }
 
   @override

--- a/packages/atlas/lib/src/screen_coordinate.dart
+++ b/packages/atlas/lib/src/screen_coordinate.dart
@@ -1,18 +1,30 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
 
 /// A pair of x and y coordinates.
 /// The `x` and `y` coordinates are stored as screen pixels (not display pixels)
 /// relative to the top of the map, not top left of the whole screen.
-class ScreenCoordinate {
+class ScreenCoordinates {
   /// The x coordinate in screen pixels.
   final int x;
 
   /// The y coordinate in screen pixels.
   final int y;
 
-  const ScreenCoordinate({
+  const ScreenCoordinates({
     @required this.x,
     @required this.y,
   })  : assert(x != null),
         assert(y != null);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+    final ScreenCoordinates typedOther = other;
+    return x == typedOther.x && y == typedOther.y;
+  }
+
+  @override
+  int get hashCode => x.hashCode ^ y.hashCode;
 }

--- a/packages/atlas/test/screen_coordinate_test.dart
+++ b/packages/atlas/test/screen_coordinate_test.dart
@@ -1,0 +1,30 @@
+import 'package:atlas/atlas.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+main() {
+  group('ScreenCoordinate', () {
+    test('should thow AssertionError if x is null', () {
+      try {
+        ScreenCoordinate(
+          x: null,
+          y: 1,
+        );
+        fail('should throw AssertionError');
+      } catch (error) {
+        expect(error, isAssertionError);
+      }
+    });
+
+    test('should throw AssertionError if y is null', () {
+      try {
+        ScreenCoordinate(
+          x: 1,
+          y: null,
+        );
+        fail('should throw AssertionError');
+      } catch (error) {
+        expect(error, isAssertionError);
+      }
+    });
+  });
+}

--- a/packages/atlas/test/screen_coordinate_test.dart
+++ b/packages/atlas/test/screen_coordinate_test.dart
@@ -28,22 +28,18 @@ void main() {
     });
 
     test('different instances with same properties should be equal', () {
-      final screenCoord1 =
-          ScreenCoordinates(x: 1, y: 2);
-      final screenCoord2 =
-          ScreenCoordinates(x: 1, y: 2);
+      final screenCoord1 = ScreenCoordinates(x: 1, y: 2);
+      final screenCoord2 = ScreenCoordinates(x: 1, y: 2);
 
       expect(screenCoord1, screenCoord2);
     });
 
-    test('different instances with different properties should NOT be equal', () {
-      final screenCoord1 =
-          ScreenCoordinates(x: 1, y: 2);
-      final screenCoord2 =
-          ScreenCoordinates(x: 1, y: 3);
+    test('different instances with different properties should NOT be equal',
+        () {
+      final screenCoord1 = ScreenCoordinates(x: 1, y: 2);
+      final screenCoord2 = ScreenCoordinates(x: 1, y: 3);
 
       expect(screenCoord1, isNot(equals(screenCoord2)));
     });
-    
   });
 }

--- a/packages/atlas/test/screen_coordinate_test.dart
+++ b/packages/atlas/test/screen_coordinate_test.dart
@@ -1,7 +1,7 @@
 import 'package:atlas/atlas.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-main() {
+void main() {
   group('ScreenCoordinate', () {
     test('should thow AssertionError if x is null', () {
       try {

--- a/packages/atlas/test/screen_coordinate_test.dart
+++ b/packages/atlas/test/screen_coordinate_test.dart
@@ -41,5 +41,11 @@ void main() {
 
       expect(screenCoord1, isNot(equals(screenCoord2)));
     });
+
+    test('should override hashCode', () {
+      final screenCoord = ScreenCoordinates(x: 1, y: 2);
+      expect(1.hashCode, screenCoord.x.hashCode);
+      expect(2.hashCode, screenCoord.y.hashCode);
+    });
   });
 }

--- a/packages/atlas/test/screen_coordinate_test.dart
+++ b/packages/atlas/test/screen_coordinate_test.dart
@@ -26,5 +26,24 @@ main() {
         expect(error, isAssertionError);
       }
     });
+
+    test('different instances with same properties should be equal', () {
+      final screenCoord1 =
+          ScreenCoordinates(x: 1, y: 2);
+      final screenCoord2 =
+          ScreenCoordinates(x: 1, y: 2);
+
+      expect(screenCoord1, screenCoord2);
+    });
+
+    test('different instances with different properties should NOT be equal', () {
+      final screenCoord1 =
+          ScreenCoordinates(x: 1, y: 2);
+      final screenCoord2 =
+          ScreenCoordinates(x: 1, y: 3);
+
+      expect(screenCoord1, isNot(equals(screenCoord2)));
+    });
+    
   });
 }

--- a/packages/atlas/test/screen_coordinate_test.dart
+++ b/packages/atlas/test/screen_coordinate_test.dart
@@ -44,8 +44,7 @@ void main() {
 
     test('should override hashCode', () {
       final screenCoord = ScreenCoordinates(x: 1, y: 2);
-      expect(1.hashCode, screenCoord.x.hashCode);
-      expect(2.hashCode, screenCoord.y.hashCode);
+      expect(1.hashCode ^ 2.hashCode, screenCoord.hashCode);
     });
   });
 }

--- a/packages/atlas/test/screen_coordinate_test.dart
+++ b/packages/atlas/test/screen_coordinate_test.dart
@@ -5,7 +5,7 @@ main() {
   group('ScreenCoordinate', () {
     test('should thow AssertionError if x is null', () {
       try {
-        ScreenCoordinate(
+        ScreenCoordinates(
           x: null,
           y: 1,
         );
@@ -17,7 +17,7 @@ main() {
 
     test('should throw AssertionError if y is null', () {
       try {
-        ScreenCoordinate(
+        ScreenCoordinates(
           x: 1,
           y: null,
         );


### PR DESCRIPTION
I added ScreenCoordinates to Atlas so that we can change between Screen- and GeoCoordinates(LatLng). Therefore, I added a new class ScreenCoordinate and created two new abstract methods getLatLng() and getScreenCoordinate(). 