### PR TITLE
Adding Night as MapType enum

### DIFF
--- a/packages/atlas/CHANGELOG.md
+++ b/packages/atlas/CHANGELOG.md
@@ -1,5 +1,9 @@
 # atlas
 
+## v0.6.0 (2020-02-26)
+
+- Added night as `MapType` enum
+
 ## v0.5.0 (2020-02-13)
 
 - Added support for `MapType`

--- a/packages/atlas/CHANGELOG.md
+++ b/packages/atlas/CHANGELOG.md
@@ -1,6 +1,6 @@
 # atlas
 
-## v0.6.0 (2020-02-26)
+## v0.5.1 (2020-02-27)
 
 - Added night as `MapType` enum
 

--- a/packages/atlas/lib/src/map_type.dart
+++ b/packages/atlas/lib/src/map_type.dart
@@ -1,6 +1,9 @@
 /// Type of map tiles to display.
 
 enum MapType {
+  /// Normal tiles at night.
+  night,
+
   /// Do not display map tiles.
   none,
 

--- a/packages/atlas/pubspec.yaml
+++ b/packages/atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atlas
 description: An extensible map abstraction for Flutter with support for multiple map providers
-version: 0.5.0
+version: 0.6.0
 authors:
   - Jorge Coca <jcocaramos@gmail.com>
   - Felix Angelov <felangelov@gmail.com>

--- a/packages/atlas/pubspec.yaml
+++ b/packages/atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atlas
 description: An extensible map abstraction for Flutter with support for multiple map providers
-version: 0.6.0
+version: 0.5.1
 authors:
   - Jorge Coca <jcocaramos@gmail.com>
   - Felix Angelov <felangelov@gmail.com>


### PR DESCRIPTION
A map provider I'm using has a night view that I'd like to support.

![night-view](https://user-images.githubusercontent.com/6883937/75373220-7da8bf00-588f-11ea-9697-11b4fff413b2.PNG)
