### PR TITLE
version bump and changelog update to 0.5.3 for Atlas

### DIFF
--- a/packages/atlas/CHANGELOG.md
+++ b/packages/atlas/CHANGELOG.md
@@ -1,6 +1,6 @@
 # atlas
 
-## v0.5.3 (2020-4-2)
+## v0.5.3 (2020-4-3)
 
 - Added custom width support for `MarkerIcon`
 

--- a/packages/atlas/CHANGELOG.md
+++ b/packages/atlas/CHANGELOG.md
@@ -1,6 +1,6 @@
 # atlas
 
-## v0.5.2 (2020-4-2)
+## v0.5.3 (2020-4-2)
 
 - Added custom width support for `MarkerIcon`
 

--- a/packages/atlas/pubspec.yaml
+++ b/packages/atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atlas
 description: An extensible map abstraction for Flutter with support for multiple map providers
-version: 0.5.2
+version: 0.5.3
 authors:
   - Jorge Coca <jcocaramos@gmail.com>
   - Felix Angelov <felangelov@gmail.com>


### PR DESCRIPTION
Once this is merged and then published, the latest google_atlas (0.3.2) will no longer incorrectly include a breaking change. 