### PR TITLE
Implement MarkerIcon Width in GoogleAtlas

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -23,6 +23,7 @@
 **/doc/api/
 .dart_tool/
 .flutter-plugins
+.flutter-plugins-dependencies
 .packages
 .pub-cache/
 .pub/
@@ -60,6 +61,7 @@
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -38,7 +38,8 @@ android {
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
 
     buildTypes {
@@ -56,6 +57,7 @@ flutter {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    implementation 'com.android.support:multidex:1.0.3'
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
     }
 }
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,1 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableR8=true
+android.enableJetifier=true
+android.useAndroidX=true

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -65,6 +65,7 @@ class _AtlasSampleState extends State<AtlasSample> {
         },
         icon: MarkerIcon(
           assetName: 'assets/mario.png',
+          width: 50,
         ),
       )
     ],

--- a/packages/google_atlas/.gitignore
+++ b/packages/google_atlas/.gitignore
@@ -24,6 +24,7 @@ coverage/
 **/doc/api/
 .dart_tool/
 .flutter-plugins
+.flutter-plugins-dependencies
 .packages
 .pub-cache/
 .pub/

--- a/packages/google_atlas/CHANGELOG.md
+++ b/packages/google_atlas/CHANGELOG.md
@@ -1,5 +1,9 @@
 # google_atlas
 
+## v0.3.3 (2020-4-8)
+
+- Use `MarkerIcon` width value
+
 ## v0.3.2 (2020-4-2)
 
 - Fix icon asset size issue

--- a/packages/google_atlas/lib/src/google_atlas.dart
+++ b/packages/google_atlas/lib/src/google_atlas.dart
@@ -149,11 +149,18 @@ class _GoogleMapsProviderState extends State<GoogleMapsProvider> {
       bitmapDescriptor = GoogleMaps.BitmapDescriptor.fromBytes(
         await _getBytesFromAsset(
           markerIcon.assetName,
-          _getDefaultIconWidth(),
+          _getIconWidth(markerIcon.width),
         ),
       );
     } catch (_) {}
     return bitmapDescriptor;
+  }
+
+  /// Returns the icon width in pixels according the device screen.
+  int _getIconWidth(int width) {
+    return width != null
+        ? (width * ui.window.devicePixelRatio).round()
+        : _getDefaultIconWidth();
   }
 
   /// Returns the default icon width in pixels according the device screen.

--- a/packages/google_atlas/lib/src/google_atlas.dart
+++ b/packages/google_atlas/lib/src/google_atlas.dart
@@ -158,7 +158,7 @@ class _GoogleMapsProviderState extends State<GoogleMapsProvider> {
 
   /// Returns the icon width in pixels according the device screen.
   int _getIconWidth(int width) {
-    return width != null
+    return (width != null && width > 0)
         ? (width * ui.window.devicePixelRatio).round()
         : _getDefaultIconWidth();
   }

--- a/packages/google_atlas/pubspec.yaml
+++ b/packages/google_atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_atlas
 description: Google Map Provider for Atlas, an extensible map abstraction for Flutter with support for multiple map providers
-version: 0.3.2
+version: 0.3.3
 authors:
   - Jorge Coca <jcocaramos@gmail.com>
   - Felix Angelov <felangelov@gmail.com>

--- a/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
+++ b/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
@@ -204,8 +204,8 @@ main() {
     });
 
     Future<void> _testMarkerIcon(
-        WidgetTester tester, 
-        MarkerIcon markerIcon,
+      WidgetTester tester,
+      MarkerIcon markerIcon,
     ) async {
       final GoogleMaps.Marker expectedMarker = GoogleMaps.Marker(
         markerId: GoogleMaps.MarkerId('marker-1'),

--- a/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
+++ b/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
@@ -204,7 +204,9 @@ main() {
     });
 
     Future<void> _testMarkerIcon(
-        WidgetTester tester, MarkerIcon markerIcon) async {
+        WidgetTester tester, 
+        MarkerIcon markerIcon,
+    ) async {
       final GoogleMaps.Marker expectedMarker = GoogleMaps.Marker(
         markerId: GoogleMaps.MarkerId('marker-1'),
         position: GoogleMaps.LatLng(41.8781, -87.6298),

--- a/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
+++ b/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
@@ -203,7 +203,8 @@ main() {
       expect(actualMarker, equals(expectedMarker));
     });
 
-    testWidgets('able to give a Marker a MapIcon', (WidgetTester tester) async {
+    Future<void> _testMarkerIcon(
+        WidgetTester tester, MarkerIcon markerIcon) async {
       final GoogleMaps.Marker expectedMarker = GoogleMaps.Marker(
         markerId: GoogleMaps.MarkerId('marker-1'),
         position: GoogleMaps.LatLng(41.8781, -87.6298),
@@ -211,14 +212,13 @@ main() {
 
       final Set<Marker> mockMarker = Set<Marker>.from([
         Marker(
-            id: 'marker-1',
-            position: LatLng(
-              latitude: 41.8781,
-              longitude: -87.6298,
-            ),
-            icon: MarkerIcon(
-              assetName: 'assets/icon.png',
-            ))
+          id: 'marker-1',
+          position: LatLng(
+            latitude: 41.8781,
+            longitude: -87.6298,
+          ),
+          icon: markerIcon,
+        )
       ]);
 
       await tester.pumpWidget(MaterialApp(
@@ -240,6 +240,27 @@ main() {
           platformGoogleMap.markersToAdd.first;
       expect(platformGoogleMap.markerIdsToRemove.isEmpty, true);
       expect(actualMarker, equals(expectedMarker));
+    }
+
+    testWidgets('able to give a Marker a MarkerIcon',
+        (WidgetTester tester) async {
+      await _testMarkerIcon(
+        tester,
+        MarkerIcon(
+          assetName: 'assets/icon.png',
+        ),
+      );
+    });
+
+    testWidgets('able to give a Marker a MarkerIcon with custom width',
+        (WidgetTester tester) async {
+      await _testMarkerIcon(
+        tester,
+        MarkerIcon(
+          assetName: 'assets/icon.png',
+          width: 100,
+        ),
+      );
     });
 
     testWidgets('get bytes from valid asset does not crash',


### PR DESCRIPTION
Use custom width if provided through MarkerIcon.

The result is working with no issues related to different screen sizes.

**Small screen:**
![Screenshot_1586340664](https://user-images.githubusercontent.com/17030735/78778717-a1354e00-7993-11ea-8c76-5482f2214c24.png)

**Big screen:**
![Screenshot_1586340620](https://user-images.githubusercontent.com/17030735/78778751-ae523d00-7993-11ea-9175-ea6e22c288c8.png)

The example app wasn't working out-of-the-box with the latest version of Flutter, I updated it.