### PR TITLE
On camera position changed

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -104,29 +104,26 @@ class _AtlasSampleState extends State<AtlasSample> {
             onMapCreated: (controller) {
               _controller = controller;
             },
-            onCameraPositionChanged: (cameraPosition) => setState(
-              () {
-                this.showSearchAreaButton = true;
-              },
-            ),
+            onCameraPositionChanged: (_) => _showSearchAreaButton(true),
           ),
-          Visibility(
-            visible: showSearchAreaButton,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                FlatButton(
-                  child: Text('Search Area'),
-                  color: Colors.white,
-                  textColor: Colors.black,
-                  onPressed: () => setState(
-                    () {
-                      this.showSearchAreaButton = false;
-                    },
+          Padding(
+            padding: EdgeInsets.only(
+              top: 50,
+            ),
+            child: Visibility(
+              visible: showSearchAreaButton,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  FlatButton(
+                    child: Text('Search Area'),
+                    color: Colors.white,
+                    textColor: Colors.black,
+                    onPressed: () => _showSearchAreaButton(false),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
           Container(
@@ -175,6 +172,12 @@ class _AtlasSampleState extends State<AtlasSample> {
         ],
       ),
     );
+  }
+
+  void _showSearchAreaButton(bool show) {
+    setState(() {
+      this.showSearchAreaButton = show;
+    });
   }
 
   bool _shouldShowMapTypeButton() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,6 +23,7 @@ class AtlasSample extends StatefulWidget {
 
 class _AtlasSampleState extends State<AtlasSample> {
   MapType mapType = MapType.normal;
+  bool showSearchAreaButton = false;
 
   final CameraPosition _initialCameraPosition = CameraPosition(
     target: LatLng(
@@ -102,6 +103,30 @@ class _AtlasSampleState extends State<AtlasSample> {
             onMapCreated: (controller) {
               _controller = controller;
             },
+            onCameraPositionChanged: (cameraPosition) => setState(
+              () {
+                this.showSearchAreaButton = true;
+              },
+            ),
+          ),
+          Visibility(
+            visible: showSearchAreaButton,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                FlatButton(
+                  child: Text('Search Area'),
+                  color: Colors.white,
+                  textColor: Colors.black,
+                  onPressed: () => setState(
+                    () {
+                      this.showSearchAreaButton = false;
+                    },
+                  ),
+                ),
+              ],
+            ),
           ),
           Container(
             alignment: Alignment.centerRight,

--- a/packages/google_atlas/lib/src/google_atlas.dart
+++ b/packages/google_atlas/lib/src/google_atlas.dart
@@ -46,6 +46,7 @@ class GoogleAtlas extends Provider {
       onTap: onTap,
       onLongPress: onLongPress,
       onMapCreated: onMapCreated,
+      onCameraPositionChanged: onCameraPositionChanged,
     );
   }
 
@@ -67,6 +68,7 @@ class GoogleMapsProvider extends StatefulWidget {
   final ArgumentCallback<LatLng> onTap;
   final ArgumentCallback<LatLng> onLongPress;
   final ArgumentCallback<AtlasController> onMapCreated;
+  final ArgumentCallback<CameraPosition> onCameraPositionChanged;
 
   GoogleMapsProvider({
     @required this.initialCameraPosition,
@@ -78,6 +80,7 @@ class GoogleMapsProvider extends StatefulWidget {
     this.onTap,
     this.onLongPress,
     this.onMapCreated,
+    this.onCameraPositionChanged,
   });
 
   State<GoogleMapsProvider> createState() => _GoogleMapsProviderState();
@@ -95,6 +98,8 @@ class _GoogleMapsProviderState extends State<GoogleMapsProvider> {
   ArgumentCallback<LatLng> get onTap => widget.onTap;
   ArgumentCallback<LatLng> get onLongPress => widget.onLongPress;
   ArgumentCallback<AtlasController> get onMapCreated => widget.onMapCreated;
+  ArgumentCallback<CameraPosition> get onCameraPositionChanged =>
+      widget.onCameraPositionChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -113,6 +118,7 @@ class _GoogleMapsProviderState extends State<GoogleMapsProvider> {
           onTap: _toGoogleOnTap(onTap),
           onLongPress: _toGoogleOnLongPress(onLongPress),
           onMapCreated: _onMapCreated,
+          onCameraMove: (cameraPosition) => _onCameraMove(cameraPosition),
         );
       },
     );
@@ -223,5 +229,13 @@ class _GoogleMapsProviderState extends State<GoogleMapsProvider> {
     onMapCreated?.call(
       GoogleAtlasController(controller: controller),
     );
+  }
+
+  /// Callback method when camera moves
+  void _onCameraMove(GoogleMaps.CameraPosition cameraPosition) async {
+    if (onCameraPositionChanged != null) {
+      onCameraPositionChanged(
+          CameraUtils.toAtlasCameraPosition(cameraPosition));
+    }
   }
 }

--- a/packages/google_atlas/lib/src/google_atlas_controller.dart
+++ b/packages/google_atlas/lib/src/google_atlas_controller.dart
@@ -44,4 +44,10 @@ class GoogleAtlasController implements AtlasController {
         .getScreenCoordinate(LatLngUtils.toGoogleLatLng(latLng));
     return LatLngUtils.fromGoogleScreenCoordinate(googleScreenCoordinate);
   }
+
+  @override
+  Future<void> updateBoundsWithPaddingToAllSides(LatLngBounds bounds, double north, double east, double south, double west) {
+    // TODO: implement updateBoundsWithPaddingToAllSides
+    return null;
+  }
 }

--- a/packages/google_atlas/lib/src/utils/camera_utils.dart
+++ b/packages/google_atlas/lib/src/utils/camera_utils.dart
@@ -14,4 +14,17 @@ class CameraUtils {
       zoom: position.zoom,
     );
   }
+
+  /// Converts a `GoogleMaps.CameraPosition` to an `Atlas.LatLng`
+  static CameraPosition toAtlasCameraPosition(
+    GoogleMaps.CameraPosition position,
+  ) {
+    return CameraPosition(
+      target: LatLng(
+        latitude: position.target.latitude,
+        longitude: position.target.longitude,
+      ),
+      zoom: position.zoom,
+    );
+  }
 }

--- a/packages/google_atlas/pubspec.yaml
+++ b/packages/google_atlas/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  atlas: ^0.5.1
+  atlas: ^0.6.0
   google_maps_flutter: ^0.5.21+3
 
 dev_dependencies:


### PR DESCRIPTION
Implemented **onCameraPositionChanged** functionality from Atlas.

This merged PR added this method: https://github.com/bmw-tech/atlas/pull/71

Obs: tests are missing. IDK how to mock this method so I can test it.

![on_camera_position_changed](https://user-images.githubusercontent.com/4043166/78933350-19d60080-7aa1-11ea-8b0e-7c996ddac30f.gif)
