### PR TITLE
Adding getCameraPosition method

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -88,6 +88,8 @@ class _AtlasSampleState extends State<AtlasSample> {
                   );
                 },
                 onLongPress: (LatLng position) {
+                  print(
+                      'long press ${position.latitude}, ${position.longitude}');
                   setState(() {
                     _markers.add(
                       Marker(
@@ -127,8 +129,6 @@ class _AtlasSampleState extends State<AtlasSample> {
                         color: Colors.white,
                         textColor: Colors.black,
                         onPressed: () {
-                          print('Position: ${_controller.getCameraPosition()}');
-
                           BlocProvider.of<MapBloc>(context)
                             ..add(
                               MapShowSearchAreaButtonChanged(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -88,8 +88,6 @@ class _AtlasSampleState extends State<AtlasSample> {
                   );
                 },
                 onLongPress: (LatLng position) {
-                  print(
-                      'long press ${position.latitude}, ${position.longitude}');
                   setState(() {
                     _markers.add(
                       Marker(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/material.dart';
 import 'package:atlas/atlas.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:google_atlas/google_atlas.dart';
-import 'package:bloc/bloc.dart';
+
 import 'bloc/bloc.dart';
 
 void main() {
@@ -129,6 +129,8 @@ class _AtlasSampleState extends State<AtlasSample> {
                         color: Colors.white,
                         textColor: Colors.black,
                         onPressed: () {
+                          print('Position: ${_controller.getCameraPosition()}');
+
                           BlocProvider.of<MapBloc>(context)
                             ..add(
                               MapShowSearchAreaButtonChanged(

--- a/packages/atlas/CHANGELOG.md
+++ b/packages/atlas/CHANGELOG.md
@@ -1,5 +1,9 @@
 # atlas
 
+## v0.8.0 (2020-7-10)
+
+- Added `getCameraPosition` function do Atlas Controller
+
 ## v0.7.0 (2020-5-12)
 
 - Added `changeUserLocationIcon` function

--- a/packages/atlas/CHANGELOG.md
+++ b/packages/atlas/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.8.0 (2020-7-10)
 
-- Added `getCameraPosition` function do Atlas Controller
+- Added `getCameraPosition` function to Atlas Controller
 
 ## v0.7.0 (2020-5-12)
 

--- a/packages/atlas/lib/src/atlas_controller.dart
+++ b/packages/atlas/lib/src/atlas_controller.dart
@@ -7,6 +7,9 @@ abstract class AtlasController {
   /// Moves the camera to the specified `CameraPosition`
   Future<void> moveCamera(CameraPosition cameraPosition);
 
+  ///Get the current camera position
+  CameraPosition getCameraPosition();
+
   /// Updates the camera bounds based on the provided `LatLngBounds`
   /// and adds padding around the bounds based on the provided `padding`.
   Future<void> updateBounds(LatLngBounds bounds, double padding);

--- a/packages/atlas/lib/src/atlas_controller.dart
+++ b/packages/atlas/lib/src/atlas_controller.dart
@@ -7,7 +7,7 @@ abstract class AtlasController {
   /// Moves the camera to the specified `CameraPosition`
   Future<void> moveCamera(CameraPosition cameraPosition);
 
-  ///Get the current camera position
+  /// Get the current camera position
   CameraPosition getCameraPosition();
 
   /// Updates the camera bounds based on the provided `LatLngBounds`

--- a/packages/atlas/pubspec.yaml
+++ b/packages/atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atlas
 description: An extensible map abstraction for Flutter with support for multiple map providers
-version: 0.7.0
+version: 0.8.0
 repository: https://github.com/bmw-tech/atlas
 issue_tracker: https://github.com/bmw-tech/atlas/issues
 homepage: https://bmw-tech.github.io/atlas

--- a/packages/google_atlas/CHANGELOG.md
+++ b/packages/google_atlas/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.6 (2020-7-13)
 
-- Added implementation for `getCameraPosition` method (empty implementation since google-atlas doest not support the feature)
+- Added implementation for `getCameraPosition` method (empty implementation since google-atlas does not support the feature)
 
 ## v0.3.5 (2020-5-12)
 

--- a/packages/google_atlas/CHANGELOG.md
+++ b/packages/google_atlas/CHANGELOG.md
@@ -1,5 +1,9 @@
 # google_atlas
 
+## v0.3.6 (2020-7-13)
+
+- Added implementation for `getCameraPosition` method (empty implementation since google-atlas doest not support the feature)
+
 ## v0.3.5 (2020-5-12)
 
 - Added support for `changeUserLocationIcon` function (May not work on all MapProviders)

--- a/packages/google_atlas/lib/src/google_atlas_controller.dart
+++ b/packages/google_atlas/lib/src/google_atlas_controller.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 
 import 'package:atlas/atlas.dart';
 import 'package:flutter/foundation.dart';
-import 'package:google_maps_flutter/google_maps_flutter.dart' as GoogleMaps;
 import 'package:google_atlas/src/utils/utils.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart' as GoogleMaps;
 
 class GoogleAtlasController implements AtlasController {
   final GoogleMaps.GoogleMapController _controller;
@@ -54,4 +54,9 @@ class GoogleAtlasController implements AtlasController {
 
   @override
   void changeUserLocationIcon(String asset) {}
+
+  @override
+  CameraPosition getCameraPosition() {
+    return null;
+  }
 }

--- a/packages/google_atlas/pubspec.yaml
+++ b/packages/google_atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_atlas
 description: Google Map Provider for Atlas, an extensible map abstraction for Flutter with support for multiple map providers
-version: 0.3.5
+version: 0.4.0
 authors:
   - Jorge Coca <jcocaramos@gmail.com>
   - Felix Angelov <felangelov@gmail.com>
@@ -16,8 +16,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  atlas:
-    path: ../atlas
+  atlas: ^0.8.0
   google_maps_flutter: ^0.5.21+3
   rxdart: ^0.22.0
 

--- a/packages/google_atlas/pubspec.yaml
+++ b/packages/google_atlas/pubspec.yaml
@@ -16,7 +16,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  atlas: ^0.7.0
+  atlas:
+    path: ../atlas
   google_maps_flutter: ^0.5.21+3
   rxdart: ^0.22.0
 

--- a/packages/google_atlas/pubspec.yaml
+++ b/packages/google_atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_atlas
 description: Google Map Provider for Atlas, an extensible map abstraction for Flutter with support for multiple map providers
-version: 0.4.0
+version: 0.3.6
 authors:
   - Jorge Coca <jcocaramos@gmail.com>
   - Felix Angelov <felangelov@gmail.com>

--- a/packages/google_atlas/pubspec.yaml
+++ b/packages/google_atlas/pubspec.yaml
@@ -16,7 +16,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  atlas: ^0.8.0
+  atlas:
+    path: ../atlas
   google_maps_flutter: ^0.5.21+3
   rxdart: ^0.22.0
 

--- a/packages/google_atlas/test/widget_tests/google_atlas_controller_test.dart
+++ b/packages/google_atlas/test/widget_tests/google_atlas_controller_test.dart
@@ -112,5 +112,12 @@ main() {
         googleAtlasController.changeUserLocationIcon('asset');
       });
     });
+
+    group('getCameraPosition', () {
+      test('call getCameraPosition and returns null', () {
+        final cameraPosition = googleAtlasController.getCameraPosition();
+        expect(cameraPosition, null);
+      });
+    });
   });
 }


### PR DESCRIPTION
Adding getCameraPosition method to Atlas

In Google Maps implementation, I am returning null since Google Maps does not offer access to camera position after initialization.