### PR TITLE
Implementing getCameraPosition method for Google-atlas

### DIFF
--- a/packages/google_atlas/CHANGELOG.md
+++ b/packages/google_atlas/CHANGELOG.md
@@ -1,5 +1,9 @@
 # google_atlas
 
+## v0.3.6 (2020-7-13)
+
+- Added implementation for `getCameraPosition` method (empty implementation since google-atlas does not support this feature)
+
 ## v0.3.5 (2020-5-12)
 
 - Added support for `changeUserLocationIcon` function (May not work on all MapProviders)

--- a/packages/google_atlas/lib/src/google_atlas_controller.dart
+++ b/packages/google_atlas/lib/src/google_atlas_controller.dart
@@ -56,7 +56,7 @@ class GoogleAtlasController implements AtlasController {
   void changeUserLocationIcon(String asset) {}
 
   @override
-  Future<CameraPosition> getCameraPosition() async {
+  CameraPosition getCameraPosition() {
     return null;
   }
 }

--- a/packages/google_atlas/lib/src/google_atlas_controller.dart
+++ b/packages/google_atlas/lib/src/google_atlas_controller.dart
@@ -56,7 +56,7 @@ class GoogleAtlasController implements AtlasController {
   void changeUserLocationIcon(String asset) {}
 
   @override
-  CameraPosition getCameraPosition() {
+  Future<CameraPosition> getCameraPosition() async {
     return null;
   }
 }

--- a/packages/google_atlas/lib/src/google_atlas_controller.dart
+++ b/packages/google_atlas/lib/src/google_atlas_controller.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 
 import 'package:atlas/atlas.dart';
 import 'package:flutter/foundation.dart';
-import 'package:google_maps_flutter/google_maps_flutter.dart' as GoogleMaps;
 import 'package:google_atlas/src/utils/utils.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart' as GoogleMaps;
 
 class GoogleAtlasController implements AtlasController {
   final GoogleMaps.GoogleMapController _controller;
@@ -54,4 +54,9 @@ class GoogleAtlasController implements AtlasController {
 
   @override
   void changeUserLocationIcon(String asset) {}
+
+  @override
+  CameraPosition getCameraPosition() {
+    return null;
+  }
 }

--- a/packages/google_atlas/pubspec.yaml
+++ b/packages/google_atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_atlas
 description: Google Map Provider for Atlas, an extensible map abstraction for Flutter with support for multiple map providers
-version: 0.3.5
+version: 0.3.6
 authors:
   - Jorge Coca <jcocaramos@gmail.com>
   - Felix Angelov <felangelov@gmail.com>
@@ -16,7 +16,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  atlas: ^0.7.0
+  atlas: ^0.8.0
   google_maps_flutter: ^0.5.21+3
   rxdart: ^0.22.0
 

--- a/packages/google_atlas/test/widget_tests/google_atlas_controller_test.dart
+++ b/packages/google_atlas/test/widget_tests/google_atlas_controller_test.dart
@@ -114,8 +114,8 @@ main() {
     });
 
     group('getCameraPosition', () {
-      test('call getCameraPosition and returns null', () async {
-        final cameraPosition = await googleAtlasController.getCameraPosition();
+      test('call getCameraPosition and returns null', () {
+        final cameraPosition = googleAtlasController.getCameraPosition();
         expect(cameraPosition, null);
       });
     });

--- a/packages/google_atlas/test/widget_tests/google_atlas_controller_test.dart
+++ b/packages/google_atlas/test/widget_tests/google_atlas_controller_test.dart
@@ -112,5 +112,12 @@ main() {
         googleAtlasController.changeUserLocationIcon('asset');
       });
     });
+
+    group('getCameraPosition', () {
+      test('call getCameraPosition and returns null', () {
+        final cameraPosition = googleAtlasController.getCameraPosition();
+        expect(cameraPosition, null);
+      });
+    });
   });
 }

--- a/packages/google_atlas/test/widget_tests/google_atlas_controller_test.dart
+++ b/packages/google_atlas/test/widget_tests/google_atlas_controller_test.dart
@@ -114,8 +114,8 @@ main() {
     });
 
     group('getCameraPosition', () {
-      test('call getCameraPosition and returns null', () {
-        final cameraPosition = googleAtlasController.getCameraPosition();
+      test('call getCameraPosition and returns null', () async {
+        final cameraPosition = await googleAtlasController.getCameraPosition();
         expect(cameraPosition, null);
       });
     });


### PR DESCRIPTION
Implementing getCameraPosition method for Google-atlas
It depends on PR: https://github.com/bmw-tech/atlas/pull/84
