### PR TITLE
upgraded rxdart, google maps and bloc

### DIFF
--- a/example/lib/bloc/map_bloc.dart
+++ b/example/lib/bloc/map_bloc.dart
@@ -3,20 +3,19 @@ import 'package:rxdart/rxdart.dart';
 import 'bloc.dart';
 
 class MapBloc extends Bloc<MapEvent, MapState> {
-  @override
-  MapState get initialState => MapState.initial();
+  MapBloc() : super(MapState.initial());
 
   @override
-  Stream<MapState> transformEvents(
-      Stream<MapEvent> events, Stream<MapState> Function(MapEvent event) next) {
-    final observableStream = events as Observable<MapEvent>;
+  Stream<Transition<MapEvent, MapState>> transformEvents(
+      Stream<MapEvent> events,
+      TransitionFunction<MapEvent, MapState> transitionFn) {
     final nonDebounceStream =
-        observableStream.where((event) => event is! MapCameraPositionChanged);
-    final debounceStream = observableStream
+        events.where((event) => event is! MapCameraPositionChanged);
+    final debounceStream = events
         .where((event) => event is MapCameraPositionChanged)
         .debounceTime(Duration(milliseconds: 200));
     return super.transformEvents(
-        MergeStream([nonDebounceStream, debounceStream]), next);
+        MergeStream([nonDebounceStream, debounceStream]), transitionFn);
   }
 
   @override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:atlas/atlas.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:google_atlas/google_atlas.dart';
-import 'package:bloc/bloc.dart';
 import 'bloc/bloc.dart';
 
 void main() {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_bloc: ^2.0.0
+  flutter_bloc: ^6.0.5
   equatable: ^1.1.1
   google_atlas:
     path: ../packages/google_atlas

--- a/packages/google_atlas/CHANGELOG.md
+++ b/packages/google_atlas/CHANGELOG.md
@@ -1,5 +1,12 @@
 # google_atlas
 
+## v0.7.0 (2020-9-24)
+
+- Ensured compatibility to Flutter 1.20.4
+- Upgrade outdated RxDart package to 0.24.1
+- Upgrade Google Maps Flutter to 0.5.33
+- Upgrade Flutter Bloc to 6.0.5
+
 ## v0.6.0 (2020-9-23)
 
 - `onPoiTap` callback added to Atlas Map

--- a/packages/google_atlas/pubspec.yaml
+++ b/packages/google_atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_atlas
 description: Google Map Provider for Atlas, an extensible map abstraction for Flutter with support for multiple map providers
-version: 0.6.0
+version: 0.7.0
 authors:
   - Jorge Coca <jcocaramos@gmail.com>
   - Felix Angelov <felangelov@gmail.com>
@@ -17,8 +17,8 @@ dependencies:
   flutter:
     sdk: flutter
   atlas: ^0.12.0
-  google_maps_flutter: ^0.5.21+3
-  rxdart: ^0.22.0
+  google_maps_flutter: ^0.5.33
+  rxdart: ^0.24.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Ensured compatibility to Flutter 1.20.4
- Upgrade outdated RxDart package to 0.24.1
- Upgrade Google Maps Flutter to 0.5.33
- Upgrade Flutter Bloc to 6.0.5