### PR TITLE
onPan callback added

### DIFF
--- a/packages/atlas/CHANGELOG.md
+++ b/packages/atlas/CHANGELOG.md
@@ -1,6 +1,6 @@
 # atlas
 
-## v0.13.0 (2020-11-12)
+## v0.12.1 (2020-11-12)
 
 - `onPan` callback added to Atlas Map
 

--- a/packages/atlas/CHANGELOG.md
+++ b/packages/atlas/CHANGELOG.md
@@ -1,6 +1,6 @@
 # atlas
 
-## v0.12.1 (2020-11-12)
+## v0.12.2 (2020-11-12)
 
 - `onPan` callback added to Atlas Map
 

--- a/packages/atlas/CHANGELOG.md
+++ b/packages/atlas/CHANGELOG.md
@@ -1,5 +1,9 @@
 # atlas
 
+## v0.13.0 (2020-11-12)
+
+- `onPan` callback added to Atlas Map
+
 ## v0.12.1 (2020-9-30)
 
 - Added `heading` to Marker object
@@ -15,8 +19,6 @@
 ## v0.10.0 (2020-8-19)
 
 - Added `mapLanguage` property to provide map languages support
-
-# atlas
 
 ## v0.9.0 (2020-7-22)
 

--- a/packages/atlas/lib/src/atlas.dart
+++ b/packages/atlas/lib/src/atlas.dart
@@ -100,7 +100,7 @@ class Atlas extends StatelessWidget {
   final MapLanguage mapLanguage;
 
   /// `onPan` gets called when the map is panned by user pan gesture.
-  final ArgumentCallback<bool> onPan;
+  final VoidCallback onPan;
 
   Atlas({
     Key key,

--- a/packages/atlas/lib/src/atlas.dart
+++ b/packages/atlas/lib/src/atlas.dart
@@ -99,6 +99,9 @@ class Atlas extends StatelessWidget {
   /// Defaults to [MapLanguage.enUs].
   final MapLanguage mapLanguage;
 
+  /// `onPan` gets called when the map is panned by user pan gesture.
+  final ArgumentCallback<bool> onPan;
+
   Atlas({
     Key key,
     @required this.initialCameraPosition,
@@ -118,6 +121,7 @@ class Atlas extends StatelessWidget {
     this.onMapCreated,
     this.onCameraPositionChanged,
     this.onLocationChanged,
+    this.onPan,
   })  : assert(initialCameraPosition != null),
         markers = markers ?? Set<Marker>(),
         circles = circles ?? Set<Circle>(),
@@ -151,6 +155,7 @@ class Atlas extends StatelessWidget {
       mapLanguage: mapLanguage,
       onMapCreated: onMapCreated,
       onCameraPositionChanged: onCameraPositionChanged,
+      onPan: onPan,
     );
   }
 }

--- a/packages/atlas/lib/src/provider.dart
+++ b/packages/atlas/lib/src/provider.dart
@@ -29,6 +29,7 @@ abstract class Provider {
     final ArgumentCallback<AtlasController> onMapCreated,
     final ArgumentCallback<CameraPosition> onCameraPositionChanged,
     final ArgumentCallback<LatLng> onLocationChanged,
+    final ArgumentCallback<bool> onPan,
     final bool showMyLocation,
     final bool showMyLocationButton,
     final bool followMyLocation,

--- a/packages/atlas/lib/src/provider.dart
+++ b/packages/atlas/lib/src/provider.dart
@@ -29,7 +29,7 @@ abstract class Provider {
     final ArgumentCallback<AtlasController> onMapCreated,
     final ArgumentCallback<CameraPosition> onCameraPositionChanged,
     final ArgumentCallback<LatLng> onLocationChanged,
-    final ArgumentCallback<bool> onPan,
+    final VoidCallback onPan,
     final bool showMyLocation,
     final bool showMyLocationButton,
     final bool followMyLocation,

--- a/packages/atlas/pubspec.yaml
+++ b/packages/atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atlas
 description: An extensible map abstraction for Flutter with support for multiple map providers
-version: 0.12.1
+version: 0.13.0
 repository: https://github.com/bmw-tech/atlas
 issue_tracker: https://github.com/bmw-tech/atlas/issues
 homepage: https://bmw-tech.github.io/atlas

--- a/packages/atlas/pubspec.yaml
+++ b/packages/atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atlas
 description: An extensible map abstraction for Flutter with support for multiple map providers
-version: 0.13.0
+version: 0.12.1
 repository: https://github.com/bmw-tech/atlas
 issue_tracker: https://github.com/bmw-tech/atlas/issues
 homepage: https://bmw-tech.github.io/atlas

--- a/packages/atlas/pubspec.yaml
+++ b/packages/atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atlas
 description: An extensible map abstraction for Flutter with support for multiple map providers
-version: 0.12.1
+version: 0.12.2
 repository: https://github.com/bmw-tech/atlas
 issue_tracker: https://github.com/bmw-tech/atlas/issues
 homepage: https://bmw-tech.github.io/atlas

--- a/packages/atlas/test/atlas_test.dart
+++ b/packages/atlas/test/atlas_test.dart
@@ -978,9 +978,8 @@ main() {
     testWidgets(
         'should call provider build method with correct arguments when onPan is provided',
         (WidgetTester tester) async {
-      final Function(bool) onPan = (bool wasPanned) {
-        print('onPan $wasPanned');
-      };
+      final VoidCallback onPan = () {};
+
       when(provider.build(
         initialCameraPosition: initialCameraPosition,
         markers: Set<Marker>(),

--- a/packages/atlas/test/atlas_test.dart
+++ b/packages/atlas/test/atlas_test.dart
@@ -974,5 +974,54 @@ main() {
         ),
       ).called(1);
     });
+
+    testWidgets(
+        'should call provider build method with correct arguments when onPan is provided',
+        (WidgetTester tester) async {
+      final Function(bool) onPan = (bool wasPanned) {
+        print('onPan $wasPanned');
+      };
+      when(provider.build(
+        initialCameraPosition: initialCameraPosition,
+        markers: Set<Marker>(),
+        circles: Set<Circle>(),
+        polygons: Set<Polygon>(),
+        polylines: Set<Polyline>(),
+        onPan: onPan,
+        showMyLocation: false,
+        showMyLocationButton: false,
+        followMyLocation: false,
+        mapType: MapType.normal,
+        showTraffic: false,
+        mapLanguage: MapLanguage.enUs,
+      )).thenReturn(Container(key: mapKey));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Atlas(
+              initialCameraPosition: initialCameraPosition,
+              onPan: onPan,
+            ),
+          ),
+        ),
+      );
+      expect(find.byKey(mapKey), findsOneWidget);
+      verify(
+        provider.build(
+          initialCameraPosition: initialCameraPosition,
+          markers: Set<Marker>(),
+          circles: Set<Circle>(),
+          polygons: Set<Polygon>(),
+          polylines: Set<Polyline>(),
+          onPan: onPan,
+          showMyLocation: false,
+          showMyLocationButton: false,
+          followMyLocation: false,
+          mapType: MapType.normal,
+          showTraffic: false,
+          mapLanguage: MapLanguage.enUs,
+        ),
+      ).called(1);
+    });
   });
 }

--- a/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
+++ b/packages/google_atlas/test/widget_tests/google_atlas_widget_test.dart
@@ -50,6 +50,10 @@ main() {
       fakePlatformViewsController.reset();
     });
 
+    test('should support 3 map types', () {
+      expect(googleAtlas.supportedMapTypes.length, 3);
+    });
+
     testWidgets(
         'should return correct GoogleMap with initial camera position and no markers',
         (WidgetTester tester) async {


### PR DESCRIPTION
added onPan callback to atlas provider so the consumers are able to use it to capture when the map was panned by the user.

