### PR TITLE
workflows codecov bash uploader | fix flag names to avoid using slash

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,8 @@ jobs:
         if: success()
         run: |
           curl -s https://codecov.io/bash -o codecov.sh
-          bash codecov.sh -F ${{ matrix.package }}
+          bash codecov.sh
         env:
           CODECOV_NAME: ${{ matrix.package }}
+          FILE: ./${{ matrix.package }}/coverage/lcov.info
+          FLAG: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - uses: subosito/flutter-action@v1
         with:
           channel: ${{ matrix.channel }}
@@ -33,18 +35,10 @@ jobs:
         run: flutter test --coverage --coverage-path coverage/lcov.info
         working-directory: ${{ matrix.package }}
 
-      # - name: Upload coverage to Codecov
-      #   if: success()
-      #   run: |
-      #     curl -s https://codecov.io/bash -o codecov.sh
-      #     bash codecov.sh -F ${{ matrix.codecov-flag }}
-      #   env:
-      #     CODECOV_NAME: ${{ matrix.package }}
-
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          flags: ${{ matrix.package }}
-          file: ./${{ matrix.package }}/coverage/lcov.info
-          override_pr: ${{ github.event.number }}
-          override_commit: ${{ github.event.pull_request.head.sha }}
+        if: success()
+        run: |
+          curl -s https://codecov.io/bash -o codecov.sh
+          bash codecov.sh -F ${{ matrix.codecov-flag }}
+        env:
+          CODECOV_NAME: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,5 +42,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          flags: $CODECOV_FLAG
+          flags: ${CODECOV_FLAG}
           file: ./${{ matrix.package }}/coverage/lcov.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,5 +42,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          flags: ${CODECOV_FLAG}
+          flags: "$CODECOV_FLAG"
           file: ./${{ matrix.package }}/coverage/lcov.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,23 +23,38 @@ jobs:
         with:
           channel: ${{ matrix.channel }}
 
-      - name: Install dependencies
-        run: flutter packages get
-        working-directory: ${{ matrix.package }}
-
-      - name: Analyze
-        run: flutter analyze
-        working-directory: ${{ matrix.package }}
-
-      - name: Run tests
-        run: flutter test --coverage --coverage-path coverage/lcov.info
-        working-directory: ${{ matrix.package }}
-
-      - name: Upload coverage to Codecov
-        if: success()
+      - name: Set environment variables
         run: |
           package_str=${{ matrix.package }}
           codecov_flag="${package_str//packages\/}"
-          bash <(curl -s https://codecov.io/bash) -c -F $codecov_flag -f ./${{ matrix.package }}/coverage/lcov.info
-        env:
-          CODECOV_NAME: ${{ matrix.package }}
+          echo "CODECOV_FLAG=${codecov_flag}" >> "$GITHUB_ENV"
+      - name: Use environment variables
+        run: |
+          echo "CODECOV_FLAG=${CODECOV_FLAG}"
+          echo $CODECOV_FLAG
+      # - name: Install dependencies
+      #   run: |
+      #     package_str=${{ matrix.package }}
+      #     codecov_flag="${package_str//packages\/}"
+      #     echo "CODECOV_FLAG=${codecov_flag}" >> "$GITHUB_ENV"
+      #     flutter packages get
+      #   working-directory: ${{ matrix.package }}
+      # - name: Analyze
+      #   run: flutter analyze
+      #   working-directory: ${{ matrix.package }}
+      # - name: Run tests
+      #   run: flutter test --coverage --coverage-path coverage/lcov.info
+      #   working-directory: ${{ matrix.package }}
+      # - name: Upload coverage to Codecov
+      #   if: success()
+      #   run: |
+      #     package_str=${{ matrix.package }}
+      #     codecov_flag="${package_str//packages\/}"
+      #     bash <(curl -s https://codecov.io/bash) -c -F $codecov_flag -f ./${{ matrix.package }}/coverage/lcov.info
+      #   env:
+      #     CODECOV_NAME: ${{ matrix.package }}
+      # - name: Upload coverage to Codecov
+      #   uses: codecov/codecov-action@v1
+      #   with:
+      #     flags: $CODECOV_FLAG
+      #     file: ./${{ matrix.package }}/coverage/lcov.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,6 @@ jobs:
         if: success()
         run: |
           curl -s https://codecov.io/bash -o codecov.sh
-          bash codecov.sh -F ${{ matrix.codecov-flag }}
+          bash codecov.sh -F ${{ matrix.codecov-flag }} -f ./${{ matrix.package }}/coverage/lcov.info
         env:
           CODECOV_NAME: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,15 +27,15 @@ jobs:
 
       - name: Install dependencies
         run: flutter packages get
-        working-directory: env.PACKAGE_PREFIX/${{ matrix.package }}
+        working-directory: ${{ matrix.package }}/env.PACKAGE_PREFIX
 
       - name: Analyze
         run: flutter analyze
-        working-directory: env.PACKAGE_PREFIX/${{ matrix.package }}
+        working-directory: ${{ matrix.package }}/env.PACKAGE_PREFIX
 
       - name: Run tests
         run: flutter test --coverage --coverage-path coverage/lcov.info
-        working-directory: env.PACKAGE_PREFIX/${{ matrix.package }}
+        working-directory: ${{ matrix.package }}/env.PACKAGE_PREFIX
 
       - name: Upload coverage to Codecov
         if: success()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           text=${{ matrix.package }}
           text="${text//\//%2F}"
-          echo "::set-output name=ATLAS_PACKAGE::$text"
-          bash <(curl -s https://codecov.io/bash) -c -F ${{ env.ATLAS_PACKAGE }}
+          echo "atlas_package_name=$text" >> $GITHUB_ENV
+          bash <(curl -s https://codecov.io/bash) -c -F ${{ env.atlas_package_name }}
         env:
           CODECOV_NAME: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,6 @@ jobs:
         if: success()
         run: |
           curl -s https://codecov.io/bash -o codecov.sh
-          bash codecov.sh
+          bash codecov.sh -F "${{ matrix.package }}" -f "./${{ matrix.package }}/coverage/lcov.info"
         env:
           CODECOV_NAME: ${{ matrix.package }}
-          CODECOV_FILE: ./${{ matrix.package }}/coverage/lcov.info
-          CODECOV_FLAG: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,13 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: ${{ matrix.channel }}
+
+      - name: Install dependencies
         run: |
           package_str=${{ matrix.package }}
           codecov_flag="${package_str//packages\/}"
           echo "CODECOV_FLAG=${codecov_flag}" >> "$GITHUB_ENV"
-
-      - name: Install dependencies
-        run: flutter packages get
+          flutter packages get
         working-directory: ${{ matrix.package }}
 
       - name: Analyze

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,5 +42,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          flags: "$CODECOV_FLAG"
+          flags: ${{CODECOV_FLAG}}
           file: ./${{ matrix.package }}/coverage/lcov.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,6 @@ jobs:
         if: success()
         run: |
           curl -s https://codecov.io/bash -o codecov.sh
-          bash codecov.sh -f ${{ matrix.package }}/coverage/lcov.info
+          bash codecov.sh -F ${{ matrix.package }}
         env:
           CODECOV_NAME: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Upload coverage to Codecov
         if: success()
         run: |
-          bash <(curl -s https://codecov.io/bash) -c -F ${${{ matrix.package }}//packages\/}
+          text=${{ matrix.package }}
+          text="${text//\//%2F}"
+          echo "::set-output name=ATLAS_PACKAGE::$text"
+          bash <(curl -s https://codecov.io/bash) -c -F ${{ env.ATLAS_PACKAGE }}
         env:
           CODECOV_NAME: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,11 +38,8 @@ jobs:
       - name: Upload coverage to Codecov
         if: success()
         run: |
-          if [ ${{ matrix.package }} == "packages/atlas" ]; then
-            codecov_flag=atlas
-          else
-            codecov_flag=google_atlas
-          fi
+          package_str=${{ matrix.package }}
+          codecov_flag="${package_str//packages\/}"
           bash <(curl -s https://codecov.io/bash) -c -F $codecov_flag
         env:
           CODECOV_NAME: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,15 +36,13 @@ jobs:
         working-directory: ${{ matrix.package }}
 
       - name: Upload coverage to Codecov Atlas
-        if: success() && ${{ matrix.package }} == "packages/atlas"
+        if: success()
         run: |
-          bash <(curl -s https://codecov.io/bash) -c -F atlas
-        env:
-          CODECOV_NAME: ${{ matrix.package }}
-
-      - name: Upload coverage to Codecov Google Atlas
-        if: success() && ${{ matrix.package }} == "packages/google_atlas"
-        run: |
-          bash <(curl -s https://codecov.io/bash) -c -F google_atlas
+          if [ ${{ matrix.package }} == "packages/atlas" ]; then
+            codecov_flag=atlas
+          else
+            codecov_flag=google_atlas
+          fi
+          bash <(curl -s https://codecov.io/bash) -c -F $codecov_flag
         env:
           CODECOV_NAME: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,12 +35,16 @@ jobs:
         run: flutter test --coverage --coverage-path coverage/lcov.info
         working-directory: ${{ matrix.package }}
 
-      - name: Upload coverage to Codecov
-        if: success()
+      - name: Upload coverage to Codecov Atlas
+        if: success() && ${{ matrix.package == "packages/atlas" }}
         run: |
-          text=${{ matrix.package }}
-          text="${text//\//%2F}"
-          echo "atlas_package_name=$text" >> $GITHUB_ENV
-          bash <(curl -s https://codecov.io/bash) -c -F ${{ env.atlas_package_name }}
+          bash <(curl -s https://codecov.io/bash) -c -F atlas
+        env:
+          CODECOV_NAME: ${{ matrix.package }}
+
+      - name: Upload coverage to Codecov Google Atlas
+        if: success() && ${{ matrix.package == "packages/google_atlas" }}
+        run: |
+          bash <(curl -s https://codecov.io/bash) -c -F google-atlas
         env:
           CODECOV_NAME: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,5 +42,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          flags: ${{CODECOV_FLAG}}
+          flags: ${{ env.CODECOV_FLAG }}
           file: ./${{ matrix.package }}/coverage/lcov.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,12 @@ on:
 jobs:
   build_flutter:
     runs-on: ubuntu-latest
+    env:
+      PACKAGE_PREFIX: "packages/"
 
     strategy:
       matrix:
-        package: ["packages/atlas", "packages/google_atlas"]
+        package: ["atlas", "google_atlas"]
         channel: ["stable"]
 
     steps:
@@ -25,15 +27,15 @@ jobs:
 
       - name: Install dependencies
         run: flutter packages get
-        working-directory: ${{ matrix.package }}
+        working-directory: env.PACKAGE_PREFIX/${{ matrix.package }}
 
       - name: Analyze
         run: flutter analyze
-        working-directory: ${{ matrix.package }}
+        working-directory: env.PACKAGE_PREFIX/${{ matrix.package }}
 
       - name: Run tests
         run: flutter test --coverage --coverage-path coverage/lcov.info
-        working-directory: ${{ matrix.package }}
+        working-directory: env.PACKAGE_PREFIX/${{ matrix.package }}
 
       - name: Upload coverage to Codecov
         if: success()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,10 @@ on:
 jobs:
   build_flutter:
     runs-on: ubuntu-latest
-    env:
-      PACKAGE_PREFIX: "packages/"
 
     strategy:
       matrix:
-        package: ["atlas", "google_atlas"]
+        package: ["packages/atlas", "packages/google_atlas"]
         channel: ["stable"]
 
     steps:
@@ -27,19 +25,19 @@ jobs:
 
       - name: Install dependencies
         run: flutter packages get
-        working-directory: ${{ matrix.package }}/env.PACKAGE_PREFIX
+        working-directory: ${{ matrix.package }}
 
       - name: Analyze
         run: flutter analyze
-        working-directory: ${{ matrix.package }}/env.PACKAGE_PREFIX
+        working-directory: ${{ matrix.package }}
 
       - name: Run tests
         run: flutter test --coverage --coverage-path coverage/lcov.info
-        working-directory: ${{ matrix.package }}/env.PACKAGE_PREFIX
+        working-directory: ${{ matrix.package }}
 
       - name: Upload coverage to Codecov
         if: success()
         run: |
-          bash <(curl -s https://codecov.io/bash) -c -F ${{ matrix.package }}
+          bash <(curl -s https://codecov.io/bash) -c -F ${${{ matrix.package }}//packages\/}
         env:
           CODECOV_NAME: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,18 +23,21 @@ jobs:
 
       - name: Install dependencies
         run: flutter packages get
+        working-directory: ${{ matrix.package }}
 
       - name: Analyze
         run: flutter analyze
+        working-directory: ${{ matrix.package }}
 
       - name: Run tests
         run: flutter test --coverage --coverage-path coverage/lcov.info
+        working-directory: ${{ matrix.package }}
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1
         with:
-          flags: atlas
-          file: ./coverage/lcov.info
+          flags: ${{ matrix.package }}
+          file: ./${{ matrix.package }}/coverage/lcov.info
 
   build_flutter_google_atlas:
     runs-on: ubuntu-latest
@@ -52,15 +55,18 @@ jobs:
 
       - name: Install dependencies
         run: flutter packages get
+        working-directory: ${{ matrix.package }}
 
       - name: Analyze
         run: flutter analyze
+        working-directory: ${{ matrix.package }}
 
       - name: Run tests
         run: flutter test --coverage --coverage-path coverage/lcov.info
+        working-directory: ${{ matrix.package }}
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1
         with:
-          flags: atlas
-          file: ./coverage/lcov.info
+          flags: ${{ matrix.package }}
+          file: ./${{ matrix.package }}/coverage/lcov.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,6 @@ jobs:
       - name: Upload coverage to Codecov Google Atlas
         if: success() && ${{ matrix.package }} == "packages/google_atlas"
         run: |
-          bash <(curl -s https://codecov.io/bash) -c -F google-atlas
+          bash <(curl -s https://codecov.io/bash) -c -F google_atlas
         env:
           CODECOV_NAME: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,8 @@ jobs:
         run: flutter test --coverage --coverage-path coverage/lcov.info
         working-directory: ${{ matrix.package }}
 
-      - name: Upload coverage to codecov
+      - name: Upload coverage to Codecov 
         uses: codecov/codecov-action@v1
         with:
           flags: ${{ matrix.package }}
-          file: ./${{ matrix.package }}/coverage/lcov.info
+          file: ${{ matrix.package }}/coverage/lcov.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,6 @@ jobs:
         run: |
           package_str=${{ matrix.package }}
           codecov_flag="${package_str//packages\/}"
-          bash <(curl -s https://codecov.io/bash) -c -F $codecov_flag
+          bash <(curl -s https://codecov.io/bash) -c -F $codecov_flag -f ./${{ matrix.package }}/coverage/lcov.info
         env:
           CODECOV_NAME: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,38 +23,24 @@ jobs:
         with:
           channel: ${{ matrix.channel }}
 
-      - name: Set environment variables
+      - name: Install dependencies
         run: |
           package_str=${{ matrix.package }}
           codecov_flag="${package_str//packages\/}"
           echo "CODECOV_FLAG=${codecov_flag}" >> "$GITHUB_ENV"
-      - name: Use environment variables
-        run: |
-          echo "CODECOV_FLAG=${CODECOV_FLAG}"
-          echo $CODECOV_FLAG
-      # - name: Install dependencies
-      #   run: |
-      #     package_str=${{ matrix.package }}
-      #     codecov_flag="${package_str//packages\/}"
-      #     echo "CODECOV_FLAG=${codecov_flag}" >> "$GITHUB_ENV"
-      #     flutter packages get
-      #   working-directory: ${{ matrix.package }}
-      # - name: Analyze
-      #   run: flutter analyze
-      #   working-directory: ${{ matrix.package }}
-      # - name: Run tests
-      #   run: flutter test --coverage --coverage-path coverage/lcov.info
-      #   working-directory: ${{ matrix.package }}
-      # - name: Upload coverage to Codecov
-      #   if: success()
-      #   run: |
-      #     package_str=${{ matrix.package }}
-      #     codecov_flag="${package_str//packages\/}"
-      #     bash <(curl -s https://codecov.io/bash) -c -F $codecov_flag -f ./${{ matrix.package }}/coverage/lcov.info
-      #   env:
-      #     CODECOV_NAME: ${{ matrix.package }}
-      # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v1
-      #   with:
-      #     flags: $CODECOV_FLAG
-      #     file: ./${{ matrix.package }}/coverage/lcov.info
+          flutter packages get
+        working-directory: ${{ matrix.package }}
+
+      - name: Analyze
+        run: flutter analyze
+        working-directory: ${{ matrix.package }}
+
+      - name: Run tests
+        run: flutter test --coverage --coverage-path coverage/lcov.info
+        working-directory: ${{ matrix.package }}
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          flags: $CODECOV_FLAG
+          file: ./${{ matrix.package }}/coverage/lcov.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,6 @@ jobs:
         if: success()
         run: |
           curl -s https://codecov.io/bash -o codecov.sh
-          bash codecov.sh -F ${{ matrix.codecov-flag }} -f ./${{ matrix.package }}/coverage/lcov.info
+          bash codecov.sh -f ${{ matrix.package }}/coverage/lcov.info
         env:
           CODECOV_NAME: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,5 +42,5 @@ jobs:
           bash codecov.sh
         env:
           CODECOV_NAME: ${{ matrix.package }}
-          FILE: ./${{ matrix.package }}/coverage/lcov.info
-          FLAG: ${{ matrix.package }}
+          CODECOV_FILE: ./${{ matrix.package }}/coverage/lcov.info
+          CODECOV_FLAG: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Upload coverage to Codecov
         if: success()
         run: |
-          curl -s https://codecov.io/bash -o codecov.sh
-          bash codecov.sh -c -F ${{ matrix.package }}
+          bash <(curl -s https://codecov.io/bash) -c -F ${{ matrix.package }}
         env:
           CODECOV_NAME: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,18 +17,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
       - uses: subosito/flutter-action@v1
         with:
           channel: ${{ matrix.channel }}
-
-      - name: Install dependencies
         run: |
           package_str=${{ matrix.package }}
           codecov_flag="${package_str//packages\/}"
           echo "CODECOV_FLAG=${codecov_flag}" >> "$GITHUB_ENV"
-          flutter packages get
+
+      - name: Install dependencies
+        run: flutter packages get
         working-directory: ${{ matrix.package }}
 
       - name: Analyze

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build_flutter:
@@ -33,10 +33,18 @@ jobs:
         run: flutter test --coverage --coverage-path coverage/lcov.info
         working-directory: ${{ matrix.package }}
 
-      - name: Upload coverage to Codecov 
-        if: success()
-        run: |
-          curl -s https://codecov.io/bash -o codecov.sh
-          bash codecov.sh -F ${{ matrix.codecov-flag }}
-        env:
-          CODECOV_NAME: ${{ matrix.package }}
+      # - name: Upload coverage to Codecov
+      #   if: success()
+      #   run: |
+      #     curl -s https://codecov.io/bash -o codecov.sh
+      #     bash codecov.sh -F ${{ matrix.codecov-flag }}
+      #   env:
+      #     CODECOV_NAME: ${{ matrix.package }}
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          flags: ${{ matrix.package }}
+          file: ./${{ matrix.package }}/coverage/lcov.info
+          override_pr: ${{ github.event.number }}
+          override_commit: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,14 +36,14 @@ jobs:
         working-directory: ${{ matrix.package }}
 
       - name: Upload coverage to Codecov Atlas
-        if: success() && ${{ matrix.package == "packages/atlas" }}
+        if: success() && ${{ matrix.package }} == "packages/atlas"
         run: |
           bash <(curl -s https://codecov.io/bash) -c -F atlas
         env:
           CODECOV_NAME: ${{ matrix.package }}
 
       - name: Upload coverage to Codecov Google Atlas
-        if: success() && ${{ matrix.package == "packages/google_atlas" }}
+        if: success() && ${{ matrix.package }} == "packages/google_atlas"
         run: |
           bash <(curl -s https://codecov.io/bash) -c -F google-atlas
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         run: flutter test --coverage --coverage-path coverage/lcov.info
         working-directory: ${{ matrix.package }}
 
-      - name: Upload coverage to Codecov Atlas
+      - name: Upload coverage to Codecov
         if: success()
         run: |
           if [ ${{ matrix.package }} == "packages/atlas" ]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,16 +7,18 @@ on:
     branches: [master]
 
 jobs:
-  build_flutter_atlas:
+  build_flutter:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        package: ["packages/atlas"]
+        package: ["packages/atlas", "packages/google_atlas"]
         channel: ["stable"]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - uses: subosito/flutter-action@v1
         with:
           channel: ${{ matrix.channel }}
@@ -33,40 +35,10 @@ jobs:
         run: flutter test --coverage --coverage-path coverage/lcov.info
         working-directory: ${{ matrix.package }}
 
-      - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v1
-        with:
-          flags: ${{ matrix.package }}
-          file: ./${{ matrix.package }}/coverage/lcov.info
-
-  build_flutter_google_atlas:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        package: ["packages/google_atlas"]
-        channel: ["stable"]
-
-    steps:
-      - uses: actions/checkout@v1
-      - uses: subosito/flutter-action@v1
-        with:
-          channel: ${{ matrix.channel }}
-
-      - name: Install dependencies
-        run: flutter packages get
-        working-directory: ${{ matrix.package }}
-
-      - name: Analyze
-        run: flutter analyze
-        working-directory: ${{ matrix.package }}
-
-      - name: Run tests
-        run: flutter test --coverage --coverage-path coverage/lcov.info
-        working-directory: ${{ matrix.package }}
-
-      - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v1
-        with:
-          flags: ${{ matrix.package }}
-          file: ./${{ matrix.package }}/coverage/lcov.info
+      - name: Upload coverage to Codecov
+        if: success()
+        run: |
+          curl -s https://codecov.io/bash -o codecov.sh
+          bash codecov.sh -c -F ${{ matrix.package }}
+        env:
+          CODECOV_NAME: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,9 @@ jobs:
         working-directory: ${{ matrix.package }}
 
       - name: Upload coverage to Codecov 
-        uses: codecov/codecov-action@v1
-        with:
-          flags: ${{ matrix.package }}
-          file: ${{ matrix.package }}/coverage/lcov.info
+        if: success()
+        run: |
+          curl -s https://codecov.io/bash -o codecov.sh
+          bash codecov.sh -F ${{ matrix.codecov-flag }}
+        env:
+          CODECOV_NAME: ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,38 +7,60 @@ on:
     branches: [master]
 
 jobs:
-  build_flutter:
+  build_flutter_atlas:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        package: ["packages/atlas", "packages/google_atlas"]
+        package: ["packages/atlas"]
         channel: ["stable"]
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
+      - uses: actions/checkout@v1
       - uses: subosito/flutter-action@v1
         with:
           channel: ${{ matrix.channel }}
 
       - name: Install dependencies
         run: flutter packages get
-        working-directory: ${{ matrix.package }}
 
       - name: Analyze
         run: flutter analyze
-        working-directory: ${{ matrix.package }}
 
       - name: Run tests
         run: flutter test --coverage --coverage-path coverage/lcov.info
-        working-directory: ${{ matrix.package }}
 
-      - name: Upload coverage to Codecov
-        if: success()
-        run: |
-          curl -s https://codecov.io/bash -o codecov.sh
-          bash codecov.sh -F "${{ matrix.package }}" -f "./${{ matrix.package }}/coverage/lcov.info"
-        env:
-          CODECOV_NAME: ${{ matrix.package }}
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v1
+        with:
+          flags: atlas
+          file: ./coverage/lcov.info
+
+  build_flutter_google_atlas:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        package: ["packages/google_atlas"]
+        channel: ["stable"]
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: ${{ matrix.channel }}
+
+      - name: Install dependencies
+        run: flutter packages get
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Run tests
+        run: flutter test --coverage --coverage-path coverage/lcov.info
+
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v1
+        with:
+          flags: atlas
+          file: ./coverage/lcov.info

--- a/packages/atlas/test/device_location_test.dart
+++ b/packages/atlas/test/device_location_test.dart
@@ -12,83 +12,83 @@ main() {
       }
     });
 
-    // test('should have correct properties when provided', () {
-    //   final deviceLocation = DeviceLocation(
-    //     target: LatLng(
-    //       latitude: 1.0,
-    //       longitude: 1.0,
-    //     ),
-    //     accuracy: 1.0,
-    //     altitude: 1.0,
-    //   );
-    //   expect(deviceLocation.target.latitude, 1.0);
-    //   expect(deviceLocation.target.longitude, 1.0);
-    //   expect(deviceLocation.accuracy, 1.0);
-    //   expect(deviceLocation.altitude, 1.0);
-    // });
+    test('should have correct properties when provided', () {
+      final deviceLocation = DeviceLocation(
+        target: LatLng(
+          latitude: 1.0,
+          longitude: 1.0,
+        ),
+        accuracy: 1.0,
+        altitude: 1.0,
+      );
+      expect(deviceLocation.target.latitude, 1.0);
+      expect(deviceLocation.target.longitude, 1.0);
+      expect(deviceLocation.accuracy, 1.0);
+      expect(deviceLocation.altitude, 1.0);
+    });
 
-    // test('accuracy should be zero when not provided', () {
-    //   final deviceLocation = DeviceLocation(
-    //     target: LatLng(
-    //       latitude: 1.0,
-    //       longitude: 1.0,
-    //     ),
-    //   );
-    //   expect(deviceLocation.accuracy, 0.0);
-    // });
+    test('accuracy should be zero when not provided', () {
+      final deviceLocation = DeviceLocation(
+        target: LatLng(
+          latitude: 1.0,
+          longitude: 1.0,
+        ),
+      );
+      expect(deviceLocation.accuracy, 0.0);
+    });
 
-    // test('accuracy should be null when passing null', () {
-    //   final deviceLocation = DeviceLocation(
-    //     target: LatLng(
-    //       latitude: 1.0,
-    //       longitude: 1.0,
-    //     ),
-    //     accuracy: null,
-    //   );
-    //   expect(deviceLocation.accuracy, null);
-    // });
+    test('accuracy should be null when passing null', () {
+      final deviceLocation = DeviceLocation(
+        target: LatLng(
+          latitude: 1.0,
+          longitude: 1.0,
+        ),
+        accuracy: null,
+      );
+      expect(deviceLocation.accuracy, null);
+    });
 
-    // test('different instances with same properties should be equal', () {
-    //   final deviceLocationA = DeviceLocation(
-    //     target: LatLng(
-    //       latitude: 1.0,
-    //       longitude: 1.0,
-    //     ),
-    //     accuracy: 1.0,
-    //     altitude: 1.0,
-    //   );
+    test('different instances with same properties should be equal', () {
+      final deviceLocationA = DeviceLocation(
+        target: LatLng(
+          latitude: 1.0,
+          longitude: 1.0,
+        ),
+        accuracy: 1.0,
+        altitude: 1.0,
+      );
 
-    //   final deviceLocationB = DeviceLocation(
-    //     target: LatLng(
-    //       latitude: 1.0,
-    //       longitude: 1.0,
-    //     ),
-    //     accuracy: 1.0,
-    //     altitude: 1.0,
-    //   );
+      final deviceLocationB = DeviceLocation(
+        target: LatLng(
+          latitude: 1.0,
+          longitude: 1.0,
+        ),
+        accuracy: 1.0,
+        altitude: 1.0,
+      );
 
-    //   expect(deviceLocationA, deviceLocationB);
-    // });
+      expect(deviceLocationA, deviceLocationB);
+    });
 
-    // test('should override hashCode properly', () {
-    //   final double latitude = 1.0;
-    //   final double longitude = 1.0;
-    //   final double accuracy = 1.0;
-    //   final double altitude = 1.0;
+    test('should override hashCode properly', () {
+      final double latitude = 1.0;
+      final double longitude = 1.0;
+      final double accuracy = 1.0;
+      final double altitude = 1.0;
 
-    //   final deviceLocation = DeviceLocation(
-    //     target: LatLng(
-    //       latitude: latitude,
-    //       longitude: longitude,
-    //     ),
-    //     accuracy: accuracy,
-    //     altitude: altitude,
-    //   );
-    //   expect(
-    //       deviceLocation.hashCode,
-    //       deviceLocation.target.hashCode ^
-    //           deviceLocation.accuracy.hashCode ^
-    //           deviceLocation.altitude.hashCode);
-    // });
+      final deviceLocation = DeviceLocation(
+        target: LatLng(
+          latitude: latitude,
+          longitude: longitude,
+        ),
+        accuracy: accuracy,
+        altitude: altitude,
+      );
+      expect(
+          deviceLocation.hashCode,
+          deviceLocation.target.hashCode ^
+              deviceLocation.accuracy.hashCode ^
+              deviceLocation.altitude.hashCode);
+    });
   });
 }

--- a/packages/atlas/test/device_location_test.dart
+++ b/packages/atlas/test/device_location_test.dart
@@ -12,83 +12,83 @@ main() {
       }
     });
 
-    test('should have correct properties when provided', () {
-      final deviceLocation = DeviceLocation(
-        target: LatLng(
-          latitude: 1.0,
-          longitude: 1.0,
-        ),
-        accuracy: 1.0,
-        altitude: 1.0,
-      );
-      expect(deviceLocation.target.latitude, 1.0);
-      expect(deviceLocation.target.longitude, 1.0);
-      expect(deviceLocation.accuracy, 1.0);
-      expect(deviceLocation.altitude, 1.0);
-    });
+    // test('should have correct properties when provided', () {
+    //   final deviceLocation = DeviceLocation(
+    //     target: LatLng(
+    //       latitude: 1.0,
+    //       longitude: 1.0,
+    //     ),
+    //     accuracy: 1.0,
+    //     altitude: 1.0,
+    //   );
+    //   expect(deviceLocation.target.latitude, 1.0);
+    //   expect(deviceLocation.target.longitude, 1.0);
+    //   expect(deviceLocation.accuracy, 1.0);
+    //   expect(deviceLocation.altitude, 1.0);
+    // });
 
-    test('accuracy should be zero when not provided', () {
-      final deviceLocation = DeviceLocation(
-        target: LatLng(
-          latitude: 1.0,
-          longitude: 1.0,
-        ),
-      );
-      expect(deviceLocation.accuracy, 0.0);
-    });
+    // test('accuracy should be zero when not provided', () {
+    //   final deviceLocation = DeviceLocation(
+    //     target: LatLng(
+    //       latitude: 1.0,
+    //       longitude: 1.0,
+    //     ),
+    //   );
+    //   expect(deviceLocation.accuracy, 0.0);
+    // });
 
-    test('accuracy should be null when passing null', () {
-      final deviceLocation = DeviceLocation(
-        target: LatLng(
-          latitude: 1.0,
-          longitude: 1.0,
-        ),
-        accuracy: null,
-      );
-      expect(deviceLocation.accuracy, null);
-    });
+    // test('accuracy should be null when passing null', () {
+    //   final deviceLocation = DeviceLocation(
+    //     target: LatLng(
+    //       latitude: 1.0,
+    //       longitude: 1.0,
+    //     ),
+    //     accuracy: null,
+    //   );
+    //   expect(deviceLocation.accuracy, null);
+    // });
 
-    test('different instances with same properties should be equal', () {
-      final deviceLocationA = DeviceLocation(
-        target: LatLng(
-          latitude: 1.0,
-          longitude: 1.0,
-        ),
-        accuracy: 1.0,
-        altitude: 1.0,
-      );
+    // test('different instances with same properties should be equal', () {
+    //   final deviceLocationA = DeviceLocation(
+    //     target: LatLng(
+    //       latitude: 1.0,
+    //       longitude: 1.0,
+    //     ),
+    //     accuracy: 1.0,
+    //     altitude: 1.0,
+    //   );
 
-      final deviceLocationB = DeviceLocation(
-        target: LatLng(
-          latitude: 1.0,
-          longitude: 1.0,
-        ),
-        accuracy: 1.0,
-        altitude: 1.0,
-      );
+    //   final deviceLocationB = DeviceLocation(
+    //     target: LatLng(
+    //       latitude: 1.0,
+    //       longitude: 1.0,
+    //     ),
+    //     accuracy: 1.0,
+    //     altitude: 1.0,
+    //   );
 
-      expect(deviceLocationA, deviceLocationB);
-    });
+    //   expect(deviceLocationA, deviceLocationB);
+    // });
 
-    test('should override hashCode properly', () {
-      final double latitude = 1.0;
-      final double longitude = 1.0;
-      final double accuracy = 1.0;
-      final double altitude = 1.0;
+    // test('should override hashCode properly', () {
+    //   final double latitude = 1.0;
+    //   final double longitude = 1.0;
+    //   final double accuracy = 1.0;
+    //   final double altitude = 1.0;
 
-      final deviceLocation = DeviceLocation(
-        target: LatLng(
-          latitude: latitude,
-          longitude: longitude,
-        ),
-        accuracy: accuracy,
-        altitude: altitude,
-      );
-      expect(
-          deviceLocation.hashCode,
-          deviceLocation.target.hashCode ^
-              deviceLocation.accuracy.hashCode ^
-              deviceLocation.altitude.hashCode);
-    });
+    //   final deviceLocation = DeviceLocation(
+    //     target: LatLng(
+    //       latitude: latitude,
+    //       longitude: longitude,
+    //     ),
+    //     accuracy: accuracy,
+    //     altitude: altitude,
+    //   );
+    //   expect(
+    //       deviceLocation.hashCode,
+    //       deviceLocation.target.hashCode ^
+    //           deviceLocation.accuracy.hashCode ^
+    //           deviceLocation.altitude.hashCode);
+    // });
   });
 }


### PR DESCRIPTION
codecov does not accept sending a flag with slash:

- `packages/atlas`
- `packages/google_atlas`

so it needs to be replaced and the solution I achieve was to remove the prefix `packages/ `and let just the package name. 