### PR TITLE
[atlas] null safety migration

### DIFF
--- a/packages/atlas/CHANGELOG.md
+++ b/packages/atlas/CHANGELOG.md
@@ -1,5 +1,11 @@
 # atlas
 
+## v1.0.0 (2021-11-18)
+
+- Atlas now supports null safety
+- **BREAKING**: opt into null safety
+  - upgrade Dart SDK constraints to `>=2.12.0 <3.0.0`
+
 ## v0.17.5 (2021-11-17)
 
 - README.md updated

--- a/packages/atlas/lib/src/atlas.dart
+++ b/packages/atlas/lib/src/atlas.dart
@@ -11,43 +11,43 @@ class Atlas extends StatelessWidget {
   final CameraPosition initialCameraPosition;
 
   /// The [Set] of `Marker` objects which will be rendered on the map.
-  final Set<Marker> markers;
+  final Set<Marker>? markers;
 
   /// The [Set] of `Callout` objects which will be rendered on the map.
-  final Set<Callout> callouts;
+  final Set<Callout>? callouts;
 
   /// The [Set] of `Circle` objects which will be rendered on the map.
-  final Set<Circle> circles;
+  final Set<Circle>? circles;
 
   /// The [Set] of `Polygon` objects which will be rendered on the map.
-  final Set<Polygon> polygons;
+  final Set<Polygon>? polygons;
 
   /// The [Set] of `Polyline` objects which will be rendered on the map.
-  final Set<Polyline> polylines;
+  final Set<Polyline>? polylines;
 
   /// `onTap` gets called when the map is tapped.
   /// The `LatLng` of the location where the pressed event occurred is passed as an argument.
-  final ArgumentCallback<LatLng> onTap;
+  final ArgumentCallback<LatLng>? onTap;
 
   /// `onPoiTap` gets called when a valid point on the map is clicked.
   /// When the clicked place is not valid point, `onTap` gets called.
   /// The `Poi` contains the name and latitude and longitude of the valid point.
-  final ArgumentCallback<Poi> onPoiTap;
+  final ArgumentCallback<Poi>? onPoiTap;
 
   /// `onLongPress` gets called when the map is long pressed
   /// The `LatLng` of the location where the pressed event occurred is passed as an argument.
-  final ArgumentCallback<LatLng> onLongPress;
+  final ArgumentCallback<LatLng>? onLongPress;
 
   /// `onMapCreated` gets called when the map is initialized and provides an `AtlasController`
   /// which can be used to manipulate the map.
-  final ArgumentCallback<AtlasController> onMapCreated;
+  final ArgumentCallback<AtlasController>? onMapCreated;
 
   /// `onCameraPositionChanged ` gets called when the map's camera position is changed.
   /// The updated `CameraPosition ` is passed as an argument.
-  final ArgumentCallback<CameraPosition> onCameraPositionChanged;
+  final ArgumentCallback<CameraPosition>? onCameraPositionChanged;
 
   /// `onLocationChanged` callback which receives a position when the user moves
-  final ArgumentCallback<LatLng> onLocationChanged;
+  final ArgumentCallback<LatLng>? onLocationChanged;
 
   /// `showMyLocation` determines whether or not the current device location
   /// should be displayed on the map. It will default to false if not specified.
@@ -67,7 +67,7 @@ class Atlas extends StatelessWidget {
   /// * On iOS add a `NSLocationWhenInUseUsageDescription` key to your
   /// `Info.plist` file. This will automatically prompt the user for permissions
   /// when the map is loaded.
-  final bool showMyLocation;
+  final bool? showMyLocation;
 
   /// Enables or disables the my-location button.
   ///
@@ -80,11 +80,11 @@ class Atlas extends StatelessWidget {
   ///
   /// See also:
   ///   * [showMyLocation] parameter.
-  final bool showMyLocationButton;
+  final bool? showMyLocationButton;
 
   /// This option enables the map to update its camera position so that
   /// the user's current location is always shown in the center of the screen
-  final bool followMyLocation;
+  final bool? followMyLocation;
 
   /// Sets the underlying map type to be displayed.
   ///
@@ -92,42 +92,42 @@ class Atlas extends StatelessWidget {
   ///
   /// See also:
   ///   * [Provider.supportedMapTypes] parameter.
-  final MapType mapType;
+  final MapType? mapType;
 
   /// Enable real-time traffic information status
-  final bool showTraffic;
+  final bool? showTraffic;
 
   /// Sets the map exhibition language.
   ///
   /// Defaults to [MapLanguage.enUs].
-  final MapLanguage mapLanguage;
+  final MapLanguage? mapLanguage;
 
   /// `onPan` gets called when the map is panned by user pan gesture.
-  final VoidCallback onPan;
+  final VoidCallback? onPan;
 
   /// Sets the device location coordinates with accuracy.
-  final DeviceLocation deviceLocation;
+  final DeviceLocation? deviceLocation;
 
   /// Sets the device location icon asset path.
-  final String deviceLocationIconAsset;
+  final String? deviceLocationIconAsset;
 
   /// Sets the country name.
-  final String country;
+  final String? country;
 
   Atlas({
-    Key key,
-    @required this.initialCameraPosition,
-    Set<Marker> markers,
-    Set<Callout> callouts,
-    Set<Circle> circles,
-    Set<Polygon> polygons,
-    Set<Polyline> polylines,
-    bool showMyLocation,
-    bool showMyLocationButton,
-    bool followMyLocation,
-    MapType mapType,
-    bool showTraffic,
-    MapLanguage mapLanguage,
+    Key? key,
+    required this.initialCameraPosition,
+    Set<Marker>? markers,
+    Set<Callout>? callouts,
+    Set<Circle>? circles,
+    Set<Polygon>? polygons,
+    Set<Polyline>? polylines,
+    bool? showMyLocation,
+    bool? showMyLocationButton,
+    bool? followMyLocation,
+    MapType? mapType,
+    bool? showTraffic,
+    MapLanguage? mapLanguage,
     this.onTap,
     this.onPoiTap,
     this.onLongPress,
@@ -138,8 +138,7 @@ class Atlas extends StatelessWidget {
     this.deviceLocation,
     this.deviceLocationIconAsset,
     this.country,
-  })  : assert(initialCameraPosition != null),
-        markers = markers ?? Set<Marker>(),
+  })  : markers = markers ?? Set<Marker>(),
         callouts = callouts ?? Set<Callout>(),
         circles = circles ?? Set<Circle>(),
         polygons = polygons ?? Set<Polygon>(),
@@ -154,7 +153,7 @@ class Atlas extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AtlasProvider.instance.build(
+    return AtlasProvider.instance!.build(
       initialCameraPosition: initialCameraPosition,
       markers: markers,
       callouts: callouts,

--- a/packages/atlas/lib/src/atlas_controller.dart
+++ b/packages/atlas/lib/src/atlas_controller.dart
@@ -7,7 +7,7 @@ abstract class AtlasController {
   /// Moves the camera to the specified `CameraPosition` with an optional animation `​​​​​MoveCameraAnimation`.
   Future<void> moveCamera(
     CameraPosition cameraPosition, {
-    MoveCameraAnimation animation,
+    MoveCameraAnimation? animation,
   });
 
   /// Get the current camera position

--- a/packages/atlas/lib/src/atlas_provider.dart
+++ b/packages/atlas/lib/src/atlas_provider.dart
@@ -4,17 +4,17 @@ import 'package:atlas/atlas.dart';
 /// with the `Atlas` widget. `AtlasProvider` is a singleton and should be configured
 /// to use the desired `Provider` before the `Atlas` widget is rendered.
 class AtlasProvider {
-  Provider _provider;
+  Provider? _provider;
 
   AtlasProvider._();
 
   static final AtlasProvider _instance = AtlasProvider._();
 
   /// Getter for the `Provider` instance
-  static Provider get instance => _instance._provider;
+  static Provider? get instance => _instance._provider;
 
   /// Setter for the `Provider` instance
-  static set instance(Provider p) {
+  static set instance(Provider? p) {
     _instance._provider = p;
   }
 }

--- a/packages/atlas/lib/src/bounding_box_data.dart
+++ b/packages/atlas/lib/src/bounding_box_data.dart
@@ -1,5 +1,4 @@
 import 'package:atlas/atlas.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 /// Represents all information need to create the boundingBox
@@ -8,25 +7,28 @@ class BoundingBoxData {
   final LatLngBounds bounds;
 
   /// Optional 2D rectangle based on a Origin and Size `Rectangle2D`
-  final Rectangle2D rectangle2d;
+  final Rectangle2D? rectangle2d;
 
   /// Optional padding that should be applied to the bounding box
-  final EdgeInsets padding;
+  final EdgeInsets? padding;
 
   BoundingBoxData({
-    @required this.bounds,
+    required this.bounds,
     this.rectangle2d,
     this.padding,
-  }) : assert(bounds != null);
+  });
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final BoundingBoxData typedOther = other;
-    return bounds == typedOther.bounds &&
-        rectangle2d == typedOther.rectangle2d &&
-        padding == typedOther.padding;
+    if (other is BoundingBoxData) {
+      return bounds == other.bounds &&
+          rectangle2d == other.rectangle2d &&
+          padding == other.padding;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/packages/atlas/lib/src/callout.dart
+++ b/packages/atlas/lib/src/callout.dart
@@ -1,5 +1,4 @@
 import 'package:atlas/atlas.dart';
-import 'package:flutter/foundation.dart';
 
 /// Marks a geographical location on the map.
 class Callout {
@@ -10,16 +9,16 @@ class Callout {
   final LatLng position;
 
   /// The type of annotation of the `Callout`
-  final AnnotationType annotationType;
+  final AnnotationType? annotationType;
 
   /// Optional MarkerIcon used to replace default icon
-  final MarkerIcon icon;
+  final MarkerIcon? icon;
 
   /// List of information of the `Callout`
-  final List<String> texts;
+  final List<String>? texts;
 
   /// A `void Function` which is called whenever a `Callout` is tapped.
-  final void Function() onTap;
+  final void Function()? onTap;
 
   /// The z-index of the callout, used to determine relative drawing order of
   /// map overlays.
@@ -28,27 +27,29 @@ class Callout {
   final double zIndex;
 
   const Callout({
-    @required this.id,
-    @required this.position,
+    required this.id,
+    required this.position,
     this.annotationType,
     this.icon,
     this.zIndex = 0.0,
     this.texts,
     this.onTap,
-  })  : assert(id != null),
-        assert(position != null);
+  });
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final Callout typedOther = other;
-    return id == typedOther.id &&
-        position == typedOther.position &&
-        icon == typedOther.icon &&
-        zIndex == typedOther.zIndex &&
-        annotationType == typedOther.annotationType &&
-        texts == typedOther.texts;
+    if (other is Callout) {
+      return id == other.id &&
+          position == other.position &&
+          icon == other.icon &&
+          zIndex == other.zIndex &&
+          annotationType == other.annotationType &&
+          texts == other.texts;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/packages/atlas/lib/src/camera_position.dart
+++ b/packages/atlas/lib/src/camera_position.dart
@@ -1,5 +1,4 @@
 import 'package:atlas/atlas.dart';
-import 'package:flutter/foundation.dart';
 
 /// The `CameraPosition` represents the position of the map "camera",
 /// the view point from which the world is shown in the map view.
@@ -12,16 +11,19 @@ class CameraPosition {
   final double zoom;
 
   const CameraPosition({
-    @required this.target,
+    required this.target,
     this.zoom = 0.0,
-  }) : assert(target != null);
+  });
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final CameraPosition typedOther = other;
-    return target == typedOther.target && zoom == typedOther.zoom;
+    if (other is CameraPosition) {
+      return target == other.target && zoom == other.zoom;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/packages/atlas/lib/src/circle.dart
+++ b/packages/atlas/lib/src/circle.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:atlas/atlas.dart';
 import 'package:flutter/material.dart';
 
@@ -14,44 +13,45 @@ class Circle {
   final double radiusInMeters;
 
   /// Optional FillColor used to color the area inside the `Circle`.
-  final Color fillColor;
+  final Color? fillColor;
 
   /// Optional StrokeColor used to color the boundary of the `Circle`.
-  final Color strokeColor;
+  final Color? strokeColor;
 
   /// Optional StrokeWidth used to width the boundary of the `Circle`.
-  final double strokeWidth;
+  final double? strokeWidth;
 
   /// The z-index of the `Circle`, used to determine relative drawing order of
   /// map overlays.
   ///
   /// Lower values means drawn earlier, and thus appearing to be closer to the surface of the Earth.
-  final double zIndex;
+  final double? zIndex;
 
   const Circle({
-    @required this.id,
-    @required this.center,
-    @required this.radiusInMeters,
+    required this.id,
+    required this.center,
+    required this.radiusInMeters,
     this.fillColor = Colors.transparent,
     this.strokeColor = Colors.black,
     this.strokeWidth = 1.0,
     this.zIndex = 0.0,
-  })  : assert(id != null),
-        assert(center != null),
-        assert(radiusInMeters != null);
+  });
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final Circle typedOther = other;
-    return id == typedOther.id &&
-        center == typedOther.center &&
-        radiusInMeters == typedOther.radiusInMeters &&
-        fillColor == typedOther.fillColor &&
-        strokeColor == typedOther.strokeColor &&
-        strokeWidth == typedOther.strokeWidth &&
-        zIndex == typedOther.zIndex;
+    if (other is Circle) {
+      return id == other.id &&
+          center == other.center &&
+          radiusInMeters == other.radiusInMeters &&
+          fillColor == other.fillColor &&
+          strokeColor == other.strokeColor &&
+          strokeWidth == other.strokeWidth &&
+          zIndex == other.zIndex;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/packages/atlas/lib/src/device_location.dart
+++ b/packages/atlas/lib/src/device_location.dart
@@ -1,25 +1,27 @@
 import 'package:atlas/atlas.dart';
-import 'package:flutter/foundation.dart';
 
 class DeviceLocation {
   final LatLng target;
-  final double accuracy;
+  final double? accuracy;
   final double altitude;
 
   const DeviceLocation({
-    @required this.target,
+    required this.target,
     this.accuracy = 0.0,
     this.altitude = 0.0,
-  }) : assert(target != null);
+  });
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final DeviceLocation typedOther = other;
-    return target == typedOther.target &&
-        accuracy == typedOther.accuracy &&
-        altitude == typedOther.altitude;
+    if (other is DeviceLocation) {
+      return target == other.target &&
+          accuracy == other.accuracy &&
+          altitude == other.altitude;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/packages/atlas/lib/src/lat_lng.dart
+++ b/packages/atlas/lib/src/lat_lng.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 /// A pair of latitude and longitude coordinates.
 /// The `latitude` and `longitude` are stored as degrees.
 class LatLng {
@@ -10,11 +8,9 @@ class LatLng {
   final double longitude;
 
   const LatLng({
-    @required double latitude,
-    @required double longitude,
-  })  : assert(latitude != null),
-        assert(longitude != null),
-        latitude =
+    required double latitude,
+    required double longitude,
+  })  : latitude =
             (latitude < -90.0 ? -90.0 : (90.0 < latitude ? 90.0 : latitude)),
         longitude = (longitude + 180.0) % 360.0 - 180.0;
 
@@ -22,8 +18,11 @@ class LatLng {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final LatLng typedOther = other;
-    return latitude == typedOther.latitude && longitude == typedOther.longitude;
+    if (other is LatLng) {
+      return latitude == other.latitude && longitude == other.longitude;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/packages/atlas/lib/src/lat_lng_bounds.dart
+++ b/packages/atlas/lib/src/lat_lng_bounds.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:atlas/atlas.dart';
 
 /// A latitude/longitude aligned rectangle.
@@ -14,18 +13,19 @@ class LatLngBounds {
   final LatLng southwest;
 
   const LatLngBounds({
-    @required this.northeast,
-    @required this.southwest,
-  })  : assert(northeast != null),
-        assert(southwest != null);
+    required this.northeast,
+    required this.southwest,
+  });
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final LatLngBounds typedOther = other;
-    return northeast == typedOther.northeast &&
-        southwest == typedOther.southwest;
+    if (other is LatLngBounds) {
+      return northeast == other.northeast && southwest == other.southwest;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/packages/atlas/lib/src/marker.dart
+++ b/packages/atlas/lib/src/marker.dart
@@ -10,12 +10,12 @@ class Marker {
   final LatLng position;
 
   /// Optional MarkerIcon used to replace default icon.
-  final MarkerIcon icon;
+  final MarkerIcon? icon;
 
   /// A `void Function` which is called whenever a `Marker` is tapped.
-  final void Function() onTap;
+  final void Function()? onTap;
 
-  final Annotation annotation;
+  final Annotation? annotation;
 
   /// The z-index of the marker, used to determine relative drawing order of
   /// map overlays.
@@ -24,36 +24,38 @@ class Marker {
   final double zIndex;
 
   /// Specifies the anchor to be at a particular point in the marker image.
-  final Anchor anchor;
+  final Anchor? anchor;
 
   // Optional heading used to rotate the marker in degrees (eg. 0 to 360).
-  final int heading;
+  final int? heading;
 
   const Marker({
-    @required this.id,
-    @required this.position,
+    required this.id,
+    required this.position,
     this.onTap,
     this.annotation = const Annotation(),
     this.icon,
     this.zIndex = 0.0,
     this.anchor,
     this.heading,
-  })  : assert(id != null),
-        assert(position != null);
+  });
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final Marker typedOther = other;
-    return id == typedOther.id &&
-        position == typedOther.position &&
-        onTap == typedOther.onTap &&
-        annotation == typedOther.annotation &&
-        icon == typedOther.icon &&
-        zIndex == typedOther.zIndex &&
-        anchor == typedOther.anchor &&
-        heading == typedOther.heading;
+    if (other is Marker) {
+      return id == other.id &&
+          position == other.position &&
+          onTap == other.onTap &&
+          annotation == other.annotation &&
+          icon == other.icon &&
+          zIndex == other.zIndex &&
+          anchor == other.anchor &&
+          heading == other.heading;
+    } else {
+      return false;
+    }
   }
 
   @override
@@ -95,8 +97,11 @@ class Anchor {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final Anchor typedOther = other;
-    return x == typedOther.x && y == typedOther.y;
+    if (other is Anchor) {
+      return x == other.x && y == other.y;
+    } else {
+      return false;
+    }
   }
 
   @override
@@ -105,14 +110,14 @@ class Anchor {
 
 /// Text labels for a [Marker] info window.
 class Annotation {
-  final String title;
+  final String? title;
 
-  final String subTitle;
+  final String? subTitle;
 
-  final MarkerIcon icon;
+  final MarkerIcon? icon;
 
   /// A `void Function` which is called whenever a `Marker info` is tapped.
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
 
   final AnnotationType annotationType;
 
@@ -128,12 +133,15 @@ class Annotation {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final Annotation typedOther = other;
-    return title == typedOther.title &&
-        subTitle == typedOther.subTitle &&
-        icon == typedOther.icon &&
-        onTap == typedOther.onTap &&
-        annotationType == typedOther.annotationType;
+    if (other is Annotation) {
+      return title == other.title &&
+          subTitle == other.subTitle &&
+          icon == other.icon &&
+          onTap == other.onTap &&
+          annotationType == other.annotationType;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/packages/atlas/lib/src/marker_icon.dart
+++ b/packages/atlas/lib/src/marker_icon.dart
@@ -4,11 +4,11 @@ import 'dart:typed_data';
 class MarkerIcon {
   /// The [assetName] argument must not be null if [assetBytes] is null. It should name the main asset
   /// from the set of images to choose from. File should be of type png
-  final String assetName;
+  final String? assetName;
 
   /// The [assetBytes] argument must not be null if [assetName] is null.
   /// File should be of type png
-  final Uint8List assetBytes;
+  final Uint8List? assetBytes;
 
   /// The [width] argument is optional. It is the desired width in pixels.
   final int width;
@@ -27,11 +27,14 @@ class MarkerIcon {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final MarkerIcon typedOther = other;
-    return assetName == typedOther.assetName &&
-        width == typedOther.width &&
-        height == typedOther.height &&
-        assetBytes == typedOther.assetBytes;
+    if (other is MarkerIcon) {
+      return assetName == other.assetName &&
+          width == other.width &&
+          height == other.height &&
+          assetBytes == other.assetBytes;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/packages/atlas/lib/src/move_camera_animation.dart
+++ b/packages/atlas/lib/src/move_camera_animation.dart
@@ -12,22 +12,23 @@ class MoveCameraAnimation {
   /// The sequence to control the zoom animation.
   final TweenSequence<double> zoomSequence;
 
-  MoveCameraAnimation(
-      {@required this.controller,
-      @required this.panSequence,
-      @required this.zoomSequence})
-      : assert(controller != null),
-        assert(panSequence != null),
-        assert(zoomSequence != null);
+  MoveCameraAnimation({
+    required this.controller,
+    required this.panSequence,
+    required this.zoomSequence,
+  });
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final MoveCameraAnimation typedOther = other;
-    return controller == typedOther.controller &&
-        panSequence == typedOther.panSequence &&
-        zoomSequence == typedOther.zoomSequence;
+    if (other is MoveCameraAnimation) {
+      return controller == other.controller &&
+          panSequence == other.panSequence &&
+          zoomSequence == other.zoomSequence;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/packages/atlas/lib/src/poi.dart
+++ b/packages/atlas/lib/src/poi.dart
@@ -1,13 +1,12 @@
 import 'package:atlas/atlas.dart';
-import 'package:flutter/foundation.dart';
 
 /// The `Poi` represents the details of the valid points selected on the map.
 class Poi {
   ///A unique identifier of the valid point selected.
-  final String id;
+  final String? id;
 
   ///The name of the valid point selected.
-  final String name;
+  final String? name;
 
   ///The latitude and longitude of the selected valid point.
   final LatLng latLng;
@@ -15,17 +14,18 @@ class Poi {
   const Poi({
     this.id,
     this.name,
-    @required this.latLng,
-  }) : assert(latLng != null);
+    required this.latLng,
+  });
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final Poi typedOther = other;
-    return id == typedOther.id &&
-        name == typedOther.name &&
-        latLng == typedOther.latLng;
+    if (other is Poi) {
+      return id == other.id && name == other.name && latLng == other.latLng;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/packages/atlas/lib/src/polygon.dart
+++ b/packages/atlas/lib/src/polygon.dart
@@ -13,30 +13,32 @@ class Polygon {
   final int strokeWidth;
 
   /// Defines the `Color` of the stroke surrounding the polygon's shape
-  final Color strokeColor;
+  final Color? strokeColor;
 
   /// Defines the fill `Color` within the polygon's shape
   final Color fillColor;
 
   const Polygon({
-    @required this.id,
-    @required this.points,
+    required this.id,
+    required this.points,
     this.strokeWidth = 1,
     this.strokeColor = Colors.blue,
     this.fillColor = Colors.blue,
-  })  : assert(id != null),
-        assert(points != null);
+  });
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final Polygon typedOther = other;
-    return id == typedOther.id &&
-        points == typedOther.points &&
-        strokeWidth == typedOther.strokeWidth &&
-        strokeColor == typedOther.strokeColor &&
-        fillColor == typedOther.fillColor;
+    if (other is Polygon) {
+      return id == other.id &&
+          points == other.points &&
+          strokeWidth == other.strokeWidth &&
+          strokeColor == other.strokeColor &&
+          fillColor == other.fillColor;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/packages/atlas/lib/src/polyline.dart
+++ b/packages/atlas/lib/src/polyline.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:atlas/atlas.dart';
 import 'package:flutter/material.dart';
 
@@ -11,10 +10,10 @@ class Polyline {
   final List<LatLng> points;
 
   /// A `void Function` which is called whenever a `Polyline` is tapped.
-  final void Function() onTap;
+  final void Function()? onTap;
 
   /// The `Color` of the line
-  final Color color;
+  final Color? color;
 
   /// Width of the polyline, used to define the width of the line segment to be drawn.
   ///
@@ -46,8 +45,8 @@ class Polyline {
   final double zIndex;
 
   const Polyline({
-    @required this.id,
-    @required this.points,
+    required this.id,
+    required this.points,
     this.onTap,
     this.color = Colors.black,
     this.width = 10,
@@ -56,24 +55,26 @@ class Polyline {
     this.outlineWidth = 0,
     this.intervals = const <double>[],
     this.zIndex = 0.0,
-  })  : assert(id != null),
-        assert(points != null);
+  });
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final Polyline typedOther = other;
-    return id == typedOther.id &&
-        points == typedOther.points &&
-        onTap == typedOther.onTap &&
-        color == typedOther.color &&
-        width == typedOther.width &&
-        outlineColor == typedOther.outlineColor &&
-        isDottedLine == typedOther.isDottedLine &&
-        outlineWidth == typedOther.outlineWidth &&
-        intervals == typedOther.intervals &&
-        zIndex == typedOther.zIndex;
+    if (other is Polyline) {
+      return id == other.id &&
+          points == other.points &&
+          onTap == other.onTap &&
+          color == other.color &&
+          width == other.width &&
+          outlineColor == other.outlineColor &&
+          isDottedLine == other.isDottedLine &&
+          outlineWidth == other.outlineWidth &&
+          intervals == other.intervals &&
+          zIndex == other.zIndex;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/packages/atlas/lib/src/provider.dart
+++ b/packages/atlas/lib/src/provider.dart
@@ -15,30 +15,30 @@ abstract class Provider {
   /// This info can then be used to either cycle through
   /// MapTypes with a button on the GUI, or to set the initial
   /// [Atlas.mapType] property.
-  Set<MapType> supportedMapTypes;
+  Set<MapType>? supportedMapTypes;
 
   Widget build({
-    final CameraPosition initialCameraPosition,
-    final Set<Marker> markers,
-    final Set<Callout> callouts,
-    final Set<Circle> circles,
-    final Set<Polygon> polygons,
-    final Set<Polyline> polylines,
-    final ArgumentCallback<LatLng> onTap,
-    final ArgumentCallback<Poi> onPoiTap,
-    final ArgumentCallback<LatLng> onLongPress,
-    final ArgumentCallback<AtlasController> onMapCreated,
-    final ArgumentCallback<CameraPosition> onCameraPositionChanged,
-    final ArgumentCallback<LatLng> onLocationChanged,
-    final VoidCallback onPan,
-    final bool showMyLocation,
-    final bool showMyLocationButton,
-    final bool followMyLocation,
-    final MapType mapType,
-    final bool showTraffic,
-    final MapLanguage mapLanguage,
-    final DeviceLocation deviceLocation,
-    final String deviceLocationIconAsset,
-    final String country,
+    final CameraPosition? initialCameraPosition,
+    final Set<Marker>? markers,
+    final Set<Callout>? callouts,
+    final Set<Circle>? circles,
+    final Set<Polygon>? polygons,
+    final Set<Polyline>? polylines,
+    final ArgumentCallback<LatLng>? onTap,
+    final ArgumentCallback<Poi>? onPoiTap,
+    final ArgumentCallback<LatLng>? onLongPress,
+    final ArgumentCallback<AtlasController>? onMapCreated,
+    final ArgumentCallback<CameraPosition>? onCameraPositionChanged,
+    final ArgumentCallback<LatLng>? onLocationChanged,
+    final VoidCallback? onPan,
+    final bool? showMyLocation,
+    final bool? showMyLocationButton,
+    final bool? followMyLocation,
+    final MapType? mapType,
+    final bool? showTraffic,
+    final MapLanguage? mapLanguage,
+    final DeviceLocation? deviceLocation,
+    final String? deviceLocationIconAsset,
+    final String? country,
   });
 }

--- a/packages/atlas/lib/src/rectangle_2d.dart
+++ b/packages/atlas/lib/src/rectangle_2d.dart
@@ -1,16 +1,16 @@
 /// Represents a virtual rectangle of the screen
 class Rectangle2D {
   /// Represents the X-axis point of the origin coordinate
-  final double originX;
+  final double? originX;
 
   /// Represents the Y-axis point of the origin coordinate
-  final double originY;
+  final double? originY;
 
   /// Represents the width of the rectangle
-  final double width;
+  final double? width;
 
   /// Represents the height of the rectangle
-  final double height;
+  final double? height;
 
   Rectangle2D({
     this.originX,
@@ -23,11 +23,14 @@ class Rectangle2D {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final Rectangle2D typedOther = other;
-    return originX == typedOther.originX &&
-        originY == typedOther.originY &&
-        width == typedOther.width &&
-        height == typedOther.height;
+    if (other is Rectangle2D) {
+      return originX == other.originX &&
+          originY == other.originY &&
+          width == other.width &&
+          height == other.height;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/packages/atlas/lib/src/screen_coordinate.dart
+++ b/packages/atlas/lib/src/screen_coordinate.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 /// A pair of x and y coordinates.
 /// The `x` and `y` coordinates are stored as screen pixels (not display pixels)
 /// relative to the top of the map, not top left of the whole screen.
@@ -11,17 +9,19 @@ class ScreenCoordinates {
   final int y;
 
   const ScreenCoordinates({
-    @required this.x,
-    @required this.y,
-  })  : assert(x != null),
-        assert(y != null);
+    required this.x,
+    required this.y,
+  });
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    final ScreenCoordinates typedOther = other;
-    return x == typedOther.x && y == typedOther.y;
+    if (other is ScreenCoordinates) {
+      return x == other.x && y == other.y;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/packages/atlas/pubspec.yaml
+++ b/packages/atlas/pubspec.yaml
@@ -6,7 +6,7 @@ issue_tracker: https://github.com/bmw-tech/atlas/issues
 homepage: https://bmw-tech.github.io/atlas
 
 environment:
-  sdk: ">=2.10.2 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:
@@ -15,4 +15,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.0.3
+  mocktail: ^0.2.0

--- a/packages/atlas/pubspec.yaml
+++ b/packages/atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atlas
 description: An extensible map abstraction for Flutter with support for multiple map providers
-version: 0.17.5
+version: 1.0.0
 repository: https://github.com/bmw-tech/atlas
 issue_tracker: https://github.com/bmw-tech/atlas/issues
 homepage: https://bmw-tech.github.io/atlas

--- a/packages/atlas/test/atlas_provider_test.dart
+++ b/packages/atlas/test/atlas_provider_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:atlas/atlas.dart';
 
 class MockAtlasProvider extends Mock implements Provider {}

--- a/packages/atlas/test/atlas_test.dart
+++ b/packages/atlas/test/atlas_test.dart
@@ -1,13 +1,13 @@
 import 'package:atlas/atlas.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
 
 class MockProvider extends Mock implements Provider {}
 
 main() {
   group('Atlas', () {
-    Provider provider;
+    Provider? provider;
     final CameraPosition initialCameraPosition = CameraPosition(
       target: LatLng(
         latitude: 37.42796133580664,
@@ -22,41 +22,23 @@ main() {
       AtlasProvider.instance = provider;
     });
 
-    testWidgets('should throw exception if initialCameraPosition is null',
-        (WidgetTester tester) async {
-      try {
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: Atlas(
-                initialCameraPosition: null,
-              ),
-            ),
-          ),
-        );
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
     testWidgets(
         'should call provider build method with correct arguments when no map markers are provided',
         (WidgetTester tester) async {
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -68,7 +50,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -101,20 +83,20 @@ main() {
         ),
       ].toSet();
 
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: markers,
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: markers,
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -127,7 +109,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: markers,
           callouts: Set<Callout>(),
@@ -147,20 +129,20 @@ main() {
     testWidgets(
         'should call provider build method with correct arguments when no map circles are provided',
         (WidgetTester tester) async {
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -172,7 +154,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -203,20 +185,20 @@ main() {
         ),
       ].toSet();
 
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        circles: circles,
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            circles: circles,
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -229,7 +211,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -272,20 +254,20 @@ main() {
         ),
       ].toSet();
 
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        polygons: polygons,
-        polylines: Set<Polyline>(),
-        circles: Set<Circle>(),
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            polygons: polygons,
+            polylines: Set<Polyline>(),
+            circles: Set<Circle>(),
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -298,7 +280,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -333,20 +315,20 @@ main() {
         ),
       ].toSet();
 
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        polygons: Set<Polygon>(),
-        polylines: polylines,
-        circles: Set<Circle>(),
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            polygons: Set<Polygon>(),
+            polylines: polylines,
+            circles: Set<Circle>(),
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -359,7 +341,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -382,21 +364,21 @@ main() {
       final Function(LatLng) onTap = (LatLng position) {
         print('onTap ${position.latitude}, ${position.latitude}');
       };
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        onTap: onTap,
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            onTap: onTap,
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -409,7 +391,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -434,21 +416,21 @@ main() {
         print(
             'onPoiTap ${poi.name}, ${poi.latLng.latitude}, ${poi.latLng.longitude}');
       };
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        onPoiTap: onPoiTap,
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            onPoiTap: onPoiTap,
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -461,7 +443,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -485,21 +467,21 @@ main() {
       final Function(LatLng) onLongPress = (LatLng position) {
         print('onLongPress ${position.latitude}, ${position.latitude}');
       };
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        onLongPress: onLongPress,
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            onLongPress: onLongPress,
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -512,7 +494,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -533,20 +515,20 @@ main() {
     testWidgets(
         'should call provider build method with correct arguments when showMyLocation is enabled',
         (WidgetTester tester) async {
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        showMyLocation: true,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            showMyLocation: true,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -559,7 +541,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -579,20 +561,20 @@ main() {
     testWidgets(
         'should call provider build method with correct arguments when showMyLocation is not provided',
         (WidgetTester tester) async {
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -604,7 +586,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -624,20 +606,20 @@ main() {
     testWidgets(
         'should call provider build method with correct arguments when showMyLocationButton is enabled',
         (WidgetTester tester) async {
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        showMyLocation: false,
-        showMyLocationButton: true,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            showMyLocation: false,
+            showMyLocationButton: true,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -651,7 +633,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -671,20 +653,20 @@ main() {
     testWidgets(
         'should call provider build method with correct arguments when showMyLocationButton is not provided',
         (WidgetTester tester) async {
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -696,7 +678,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -716,20 +698,20 @@ main() {
     testWidgets(
         'should call provider build method with correct arguments when mapType is supplied',
         (WidgetTester tester) async {
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -741,7 +723,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -761,20 +743,20 @@ main() {
     testWidgets(
         'should call provider build method with correct arguments when showTraffic is enabled',
         (WidgetTester tester) async {
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: true,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: true,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -787,7 +769,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -822,20 +804,20 @@ main() {
             )),
       ].toSet();
 
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: markers,
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: markers,
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -848,7 +830,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: markers,
           callouts: Set<Callout>(),
@@ -868,20 +850,20 @@ main() {
     testWidgets(
         'should call provider build method with correct arguments when followMyLocation is enabled',
         (WidgetTester tester) async {
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        showMyLocation: true,
-        showMyLocationButton: true,
-        followMyLocation: true,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            showMyLocation: true,
+            showMyLocationButton: true,
+            followMyLocation: true,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -896,7 +878,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -919,21 +901,21 @@ main() {
       final Function(LatLng) onLocationChanged = (LatLng position) {
         print('onLocationChanged ${position.latitude}, ${position.latitude}');
       };
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        onLocationChanged: onLocationChanged,
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            onLocationChanged: onLocationChanged,
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -946,7 +928,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -967,20 +949,20 @@ main() {
     testWidgets(
         'should call provider build method with correct arguments when mapLanguage is provided',
         (WidgetTester tester) async {
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        showMyLocation: true,
-        showMyLocationButton: true,
-        followMyLocation: true,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.deDe,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            showMyLocation: true,
+            showMyLocationButton: true,
+            followMyLocation: true,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.deDe,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -996,7 +978,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -1018,21 +1000,21 @@ main() {
         (WidgetTester tester) async {
       final VoidCallback onPan = () {};
 
-      when(provider.build(
-        initialCameraPosition: initialCameraPosition,
-        markers: Set<Marker>(),
-        callouts: Set<Callout>(),
-        circles: Set<Circle>(),
-        polygons: Set<Polygon>(),
-        polylines: Set<Polyline>(),
-        onPan: onPan,
-        showMyLocation: false,
-        showMyLocationButton: false,
-        followMyLocation: false,
-        mapType: MapType.normal,
-        showTraffic: false,
-        mapLanguage: MapLanguage.enUs,
-      )).thenReturn(Container(key: mapKey));
+      when(() => provider!.build(
+            initialCameraPosition: initialCameraPosition,
+            markers: Set<Marker>(),
+            callouts: Set<Callout>(),
+            circles: Set<Circle>(),
+            polygons: Set<Polygon>(),
+            polylines: Set<Polyline>(),
+            onPan: onPan,
+            showMyLocation: false,
+            showMyLocationButton: false,
+            followMyLocation: false,
+            mapType: MapType.normal,
+            showTraffic: false,
+            mapLanguage: MapLanguage.enUs,
+          )).thenReturn(Container(key: mapKey));
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -1045,7 +1027,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -1075,7 +1057,7 @@ main() {
       );
 
       when(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -1103,7 +1085,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -1127,7 +1109,7 @@ main() {
       final deviceLocationIconAsset = 'path-to-the-icon-asset';
 
       when(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -1155,7 +1137,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -1179,7 +1161,7 @@ main() {
       final country = 'Japan';
 
       when(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),
@@ -1207,7 +1189,7 @@ main() {
       );
       expect(find.byKey(mapKey), findsOneWidget);
       verify(
-        provider.build(
+        () => provider!.build(
           initialCameraPosition: initialCameraPosition,
           markers: Set<Marker>(),
           callouts: Set<Callout>(),

--- a/packages/atlas/test/bounding_box_data_test.dart
+++ b/packages/atlas/test/bounding_box_data_test.dart
@@ -4,19 +4,6 @@ import 'package:atlas/atlas.dart';
 
 main() {
   group('BoundingBoxData', () {
-    test(
-      'should throw AssertionError if bounds is null',
-      () {
-        try {
-          BoundingBoxData(
-            bounds: null,
-          );
-          fail('should throw AssertionError');
-        } catch (error) {
-          expect(error, isAssertionError);
-        }
-      },
-    );
     test('should have correct properties when provided', () {
       final expectedBounds = LatLngBounds(
         northeast: LatLng(latitude: 1.0, longitude: 1.0),

--- a/packages/atlas/test/callout_test.dart
+++ b/packages/atlas/test/callout_test.dart
@@ -3,30 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 main() {
   group('Callout', () {
-    test('should throw AssertionError if id is null', () {
-      try {
-        Callout(
-          id: null,
-          position: LatLng(
-            latitude: 37.42796133580664,
-            longitude: -122.085749655962,
-          ),
-        );
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
-    test('should throw AssertionError if position is null', () {
-      try {
-        Callout(id: 'id', position: null);
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
     test('should have correct properties when no zIndex is provided', () {
       final expectedId = 'id';
       final expectedPosition = LatLng(
@@ -50,7 +26,7 @@ main() {
         latitude: 37.42796133580664,
         longitude: -122.085749655962,
       );
-      final expectedAnnotationType = null;
+      final dynamic expectedAnnotationType = null;
       final callout = Callout(
         id: expectedId,
         position: expectedPosition,

--- a/packages/atlas/test/camera_position_test.dart
+++ b/packages/atlas/test/camera_position_test.dart
@@ -3,15 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 main() {
   group('CameraPosition', () {
-    test('should throw AssertionError if target is null', () {
-      try {
-        CameraPosition(target: null);
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
     test('should have correct properties when provided', () {
       final expectedPosition = LatLng(
         latitude: 37.42796133580664,

--- a/packages/atlas/test/circle_test.dart
+++ b/packages/atlas/test/circle_test.dart
@@ -4,54 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 main() {
   group('Circle', () {
-    test('should throw AssertionError if id is null', () {
-      try {
-        Circle(
-          id: null,
-          center: LatLng(
-            latitude: 38.7439498,
-            longitude: -9.1490721,
-          ),
-          radiusInMeters: 0.0,
-        );
-
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
-    test('should throw AssertionError if center is null', () {
-      try {
-        Circle(
-          id: 'id',
-          center: null,
-          radiusInMeters: 0.0,
-        );
-
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
-    test('should throw AssertionError if radius is null', () {
-      try {
-        Circle(
-          id: 'id',
-          center: LatLng(
-            latitude: 38.7439498,
-            longitude: -9.1490721,
-          ),
-          radiusInMeters: null,
-        );
-
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
     test('should have correct properties when no fillColor is provided', () {
       final expectedId = 'id';
       final expectedCenter = LatLng(
@@ -59,7 +11,7 @@ main() {
         longitude: -9.1490721,
       );
       final expectedRadius = 10.0;
-      final expectedFillColor = null;
+      final dynamic expectedFillColor = null;
 
       final circle = Circle(
         id: expectedId,
@@ -103,7 +55,7 @@ main() {
         longitude: -9.1490721,
       );
       final expectedRadius = 10.0;
-      final expectedStrokeColor = null;
+      final dynamic expectedStrokeColor = null;
 
       final circle = Circle(
         id: expectedId,
@@ -147,7 +99,7 @@ main() {
         longitude: -9.1490721,
       );
       final expectedRadius = 10.0;
-      final expectedZIndex = null;
+      final dynamic expectedZIndex = null;
 
       final circle = Circle(
         id: expectedId,
@@ -191,7 +143,7 @@ main() {
         longitude: -9.1490721,
       );
       final expectedRadius = 10.0;
-      final expectedStrokeColor = null;
+      final dynamic expectedStrokeColor = null;
 
       final circle = Circle(
         id: expectedId,
@@ -235,7 +187,7 @@ main() {
         longitude: -9.1490721,
       );
       final expectedRadius = 10.0;
-      final expectedStrokeColor = null;
+      final dynamic expectedStrokeColor = null;
 
       final circle = Circle(
         id: expectedId,

--- a/packages/atlas/test/device_location_test.dart
+++ b/packages/atlas/test/device_location_test.dart
@@ -3,15 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 main() {
   group('DeviceLocation', () {
-    test('should throw AssertionError if target is null', () {
-      try {
-        DeviceLocation(target: null);
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
     test('should have correct properties when provided', () {
       final deviceLocation = DeviceLocation(
         target: LatLng(

--- a/packages/atlas/test/lat_lng_bounds_test.dart
+++ b/packages/atlas/test/lat_lng_bounds_test.dart
@@ -3,30 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 main() {
   group('LatLngBounds', () {
-    test('should throw AssertionError if northeast is null', () {
-      try {
-        LatLngBounds(
-          northeast: null,
-          southwest: LatLng(latitude: 0, longitude: 0),
-        );
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
-    test('should throw AssertionError if southwest is null', () {
-      try {
-        LatLngBounds(
-          northeast: LatLng(latitude: 0, longitude: 0),
-          southwest: null,
-        );
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
     test('should have correct properties when provided', () {
       final expectedPosition = LatLng(
         latitude: 37.42796133580664,

--- a/packages/atlas/test/lat_lng_test.dart
+++ b/packages/atlas/test/lat_lng_test.dart
@@ -3,30 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 main() {
   group('LatLng', () {
-    test('should throw AssertionError if latitude is null', () {
-      try {
-        LatLng(
-          latitude: null,
-          longitude: 0.0,
-        );
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
-    test('should throw AssertionError if longitude is null', () {
-      try {
-        LatLng(
-          latitude: 0.0,
-          longitude: null,
-        );
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
     test('should compute normalized latitude when latitude is < -90', () {
       final pair = LatLng(latitude: -100, longitude: 0.0);
       expect(pair.latitude, -90);

--- a/packages/atlas/test/marker_test.dart
+++ b/packages/atlas/test/marker_test.dart
@@ -3,37 +3,13 @@ import 'package:atlas/atlas.dart';
 
 main() {
   group('Marker', () {
-    test('should throw AssertionError if id is null', () {
-      try {
-        Marker(
-          id: null,
-          position: LatLng(
-            latitude: 37.42796133580664,
-            longitude: -122.085749655962,
-          ),
-        );
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
-    test('should throw AssertionError if position is null', () {
-      try {
-        Marker(id: 'id', position: null);
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
     test('should have correct properties when no onTap is provided', () {
       final expectedId = 'id';
       final expectedPosition = LatLng(
         latitude: 37.42796133580664,
         longitude: -122.085749655962,
       );
-      final expectedOnTap = null;
+      final dynamic expectedOnTap = null;
       final marker = Marker(
         id: expectedId,
         position: expectedPosition,
@@ -50,7 +26,7 @@ main() {
         latitude: 37.42796133580664,
         longitude: -122.085749655962,
       );
-      final expectedOnTap = null;
+      final dynamic expectedOnTap = null;
       final expectedZIndex = 0.0;
       final marker = Marker(
         id: expectedId,
@@ -69,7 +45,7 @@ main() {
         latitude: 37.42796133580664,
         longitude: -122.085749655962,
       );
-      final expectedOnTap = null;
+      final dynamic expectedOnTap = null;
       final expectedZIndex = 1.0;
       final marker = Marker(
         id: expectedId,
@@ -107,7 +83,7 @@ main() {
         latitude: 37.42796133580664,
         longitude: -122.085749655962,
       );
-      final expectedMarkerAnnotation = null;
+      final dynamic expectedMarkerAnnotation = null;
       final marker = Marker(
         id: expectedId,
         position: expectedPosition,
@@ -136,8 +112,8 @@ main() {
       );
       expect(marker.id, expectedId);
       expect(marker.position, expectedPosition);
-      expect(marker.annotation.title, expectedMarkerAnnotation.title);
-      expect(marker.annotation.subTitle, expectedMarkerAnnotation.subTitle);
+      expect(marker.annotation!.title, expectedMarkerAnnotation.title);
+      expect(marker.annotation!.subTitle, expectedMarkerAnnotation.subTitle);
     });
 
     test('different instances with same properties should be equal', () {
@@ -172,7 +148,7 @@ main() {
         latitude: 37.42796133580664,
         longitude: -122.085749655962,
       );
-      final expectedOnTap = null;
+      final dynamic expectedOnTap = null;
       final expectedHeading = 180;
       final marker = Marker(
         id: expectedId,

--- a/packages/atlas/test/move_camera_animation_test.dart
+++ b/packages/atlas/test/move_camera_animation_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/animation.dart';
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:atlas/atlas.dart';
 import 'package:flutter/material.dart';
@@ -24,49 +24,6 @@ class MockDoubleTween extends Mock implements Tween<double> {}
 
 main() {
   group('Move Camera Animation', () {
-    test('should throw assertion error if controller is null', () {
-      try {
-        MoveCameraAnimation(
-          controller: null,
-          panSequence: TweenSequence<LatLng>(
-              [TweenSequenceItem(tween: MockLatLngTween(), weight: 100.0)]),
-          zoomSequence: TweenSequence<double>(
-              [TweenSequenceItem(tween: MockDoubleTween(), weight: 100.0)]),
-        );
-        fail('should throw assertion error');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
-    test('should throw assertion error if panSequence is null', () {
-      try {
-        MoveCameraAnimation(
-          controller: AnimationController(vsync: MockStateTicker()),
-          panSequence: null,
-          zoomSequence: TweenSequence<double>(
-              [TweenSequenceItem(tween: MockDoubleTween(), weight: 100.0)]),
-        );
-        fail('should throw assertion error');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
-    test('should throw assertion error if zoomSequence is null', () {
-      try {
-        MoveCameraAnimation(
-          controller: AnimationController(vsync: MockStateTicker()),
-          panSequence: TweenSequence<LatLng>(
-              [TweenSequenceItem(tween: MockLatLngTween(), weight: 100.0)]),
-          zoomSequence: null,
-        );
-        fail('should throw assertion error');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
     test('should override == properly', () {
       var controller = AnimationController(vsync: MockStateTicker());
       var panSequence = TweenSequence<LatLng>(

--- a/packages/atlas/test/poi_test.dart
+++ b/packages/atlas/test/poi_test.dart
@@ -3,17 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 main() {
   group('Poi', () {
-    test('should throw AssertionError if latLng is null', () {
-      try {
-        Poi(
-          latLng: null,
-        );
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
     test('should have correct properties when provided', () {
       final latLng = LatLng(
         latitude: 37.42796133580664,

--- a/packages/atlas/test/polygon_test.dart
+++ b/packages/atlas/test/polygon_test.dart
@@ -4,47 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 main() {
   group('Polygon', () {
-    test('should throw AssertionError if id is null', () {
-      try {
-        Polygon(
-          id: null,
-          points: [
-            LatLng(
-              latitude: 48.133,
-              longitude: 11.5888,
-            ),
-            LatLng(
-              latitude: 48.233,
-              longitude: 11.5888,
-            ),
-            LatLng(
-              latitude: 48.333,
-              longitude: 11.4888,
-            ),
-          ],
-          fillColor: Colors.red,
-          strokeColor: Colors.red,
-          strokeWidth: 1,
-        );
-
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
-    test('should throw AssertionError if points is null', () {
-      try {
-        Polygon(
-          id: 'id',
-          points: null,
-        );
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
     test('should have correct properties when stroke color is NOT provided',
         () {
       final expectedId = 'id';
@@ -59,7 +18,7 @@ main() {
         )
       ];
 
-      final expectedColor = null;
+      final dynamic expectedColor = null;
 
       final polygon = Polygon(
         id: expectedId,

--- a/packages/atlas/test/polyline_test.dart
+++ b/packages/atlas/test/polyline_test.dart
@@ -4,40 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 main() {
   group('Polyline', () {
-    test('should throw AssertionError if id is null', () {
-      try {
-        Polyline(
-          id: null,
-          points: [
-            LatLng(
-              latitude: 38.7439498,
-              longitude: -9.1490721,
-            ),
-            LatLng(
-              latitude: 36.7439498,
-              longitude: 126.1490721,
-            )
-          ],
-        );
-
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
-    test('should throw AssertionError if points is null', () {
-      try {
-        Polyline(
-          id: 'id',
-          points: null,
-        );
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
     test('should have correct properties when no Color is provided', () {
       final expectedId = 'id';
       final expectedPoints = [
@@ -51,7 +17,7 @@ main() {
         )
       ];
 
-      final expectedColor = null;
+      final dynamic expectedColor = null;
 
       final polyline = Polyline(
         id: expectedId,

--- a/packages/atlas/test/screen_coordinate_test.dart
+++ b/packages/atlas/test/screen_coordinate_test.dart
@@ -3,30 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('ScreenCoordinate', () {
-    test('should thow AssertionError if x is null', () {
-      try {
-        ScreenCoordinates(
-          x: null,
-          y: 1,
-        );
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
-    test('should throw AssertionError if y is null', () {
-      try {
-        ScreenCoordinates(
-          x: 1,
-          y: null,
-        );
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
     test('different instances with same properties should be equal', () {
       final screenCoord1 = ScreenCoordinates(x: 1, y: 2);
       final screenCoord2 = ScreenCoordinates(x: 1, y: 2);


### PR DESCRIPTION
- migrated to `null safety`
- replaced `mockito` for `mocktail` (which supports `null safety`)