### PR TITLE
removed onTap from the == comparer (Marker object)

### DIFF
--- a/packages/atlas/CHANGELOG.md
+++ b/packages/atlas/CHANGELOG.md
@@ -1,5 +1,9 @@
 # atlas
 
+## v1.0.2 (2022-01-24)
+
+- Fix: removed onTap from the marker == comparer (functions from different instances will never be the same)
+
 ## v1.0.1 (2022-01-21)
 
 - Added `pulsingVisible`, `pulsingTime` and `pulsingInterval` boolean properties to the Circle object

--- a/packages/atlas/lib/src/marker.dart
+++ b/packages/atlas/lib/src/marker.dart
@@ -13,7 +13,7 @@ class Marker {
   final MarkerIcon? icon;
 
   /// A `void Function` which is called whenever a `Marker` is tapped.
-  final void Function()? onTap;
+  final VoidCallback? onTap;
 
   final Annotation? annotation;
 
@@ -47,7 +47,6 @@ class Marker {
     if (other is Marker) {
       return id == other.id &&
           position == other.position &&
-          onTap == other.onTap &&
           annotation == other.annotation &&
           icon == other.icon &&
           zIndex == other.zIndex &&
@@ -62,7 +61,6 @@ class Marker {
   int get hashCode =>
       id.hashCode ^
       position.hashCode ^
-      onTap.hashCode ^
       annotation.hashCode ^
       icon.hashCode ^
       zIndex.hashCode ^
@@ -137,7 +135,6 @@ class Annotation {
       return title == other.title &&
           subTitle == other.subTitle &&
           icon == other.icon &&
-          onTap == other.onTap &&
           annotationType == other.annotationType;
     } else {
       return false;
@@ -149,6 +146,5 @@ class Annotation {
       title.hashCode ^
       subTitle.hashCode ^
       icon.hashCode ^
-      onTap.hashCode ^
       annotationType.hashCode;
 }

--- a/packages/atlas/pubspec.yaml
+++ b/packages/atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atlas
 description: An extensible map abstraction for Flutter with support for multiple map providers
-version: 1.0.1
+version: 1.0.2
 repository: https://github.com/bmw-tech/atlas
 issue_tracker: https://github.com/bmw-tech/atlas/issues
 homepage: https://bmw-tech.github.io/atlas

--- a/packages/atlas/test/annotation_test.dart
+++ b/packages/atlas/test/annotation_test.dart
@@ -38,7 +38,6 @@ main() {
         annotation.title.hashCode ^
             annotation.subTitle.hashCode ^
             annotation.icon.hashCode ^
-            annotation.onTap.hashCode ^
             annotation.annotationType.hashCode,
       );
     });


### PR DESCRIPTION
When comparing functions from different object instances, they will never be the same.

issue reference: https://stackoverflow.com/questions/16875895/dart-member-function-equality-rules